### PR TITLE
Bug fix for values with :

### DIFF
--- a/custom_json_diff/cli.py
+++ b/custom_json_diff/cli.py
@@ -46,7 +46,7 @@ def build_args():
         "--preset",
         action="store",
         help="Preset to use",
-        choices=["cdxgen"],
+        choices=["cdxgen", "cdxgen-minimal"],
         dest="preset",
     )
     return parser.parse_args()
@@ -61,7 +61,8 @@ def main():
         diffs = get_diffs(args.input[0], args.input[1], j1, j2)
         if args.output:
             export_results(args.output, diffs)
-        print(json.dumps(diffs, indent=2))
+        else:
+            print(json.dumps(diffs, indent=2))
 
 
 if __name__ == "__main__":

--- a/custom_json_diff/cli.py
+++ b/custom_json_diff/cli.py
@@ -46,7 +46,7 @@ def build_args():
         "--preset",
         action="store",
         help="Preset to use",
-        choices=["cdxgen", "cdxgen-minimal"],
+        choices=["cdxgen", "cdxgen-extended"],
         dest="preset",
     )
     return parser.parse_args()
@@ -56,7 +56,7 @@ def main():
     args = build_args()
     result, j1, j2 = compare_dicts(args.input[0], args.input[1], args.preset, args.exclude, args.config)
     if result == 0:
-        print("Files are identical.")
+        print("No differences found.")
     else:
         diffs = get_diffs(args.input[0], args.input[1], j1, j2)
         if args.output:

--- a/custom_json_diff/custom_diff.py
+++ b/custom_json_diff/custom_diff.py
@@ -130,7 +130,7 @@ def remove_filepaths(data: Dict) -> Dict:
 def set_excluded_fields(preset: str) -> Tuple[Set[str], List[str]]:
     excluded = []
     sort_fields = []
-    if preset == "cdxgen":
+    if preset.startswith("cdxgen"):
         excluded.extend(["metadata.timestamp", "serialNumber",
                          "metadata.tools.components.[].version",
                          "metadata.tools.components.[].purl",
@@ -138,16 +138,8 @@ def set_excluded_fields(preset: str) -> Tuple[Set[str], List[str]]:
                          "components.[].properties",
                          "components.[].evidence"
                          ])
-        sort_fields.extend(["url", "content", "ref", "name", "value"])
-    elif preset == "cdxgen-minimal":
-        excluded.extend(["metadata.timestamp", "serialNumber",
-                         "metadata.tools.components.[].version",
-                         "metadata.tools.components.[].purl",
-                         "metadata.tools.components.[].bom-ref",
-                         "components.[].properties",
-                         "components.[].evidence",
-                         "components.[].licenses"
-                         ])
+        if preset == "cdxgen-extended":
+            excluded.append("components.[].licenses")
         sort_fields.extend(["url", "content", "ref", "name", "value"])
     return set(excluded), sort_fields
 

--- a/custom_json_diff/custom_diff.py
+++ b/custom_json_diff/custom_diff.py
@@ -9,6 +9,9 @@ import toml
 from json_flatten import flatten, unflatten
 
 
+DELIM = "|>"
+
+
 def check_key(key: str, exclude_keys: Set[str]) -> bool:
     return not any(key.startswith(k) for k in exclude_keys)
 
@@ -73,10 +76,10 @@ def filter_simple(flattened_data: Dict, exclude_keys: Set[str]) -> Dict:
 
 
 def get_diffs(file_1: str | Path, file_2: str | Path, json_1_data: Dict, json_2_data: Dict) -> Dict:
-    j1 = {f"{key}:{value}" for key, value in json_1_data.items()}
-    j2 = {f"{key}:{value}" for key, value in json_2_data.items()}
-    result = unflatten({value.split(":")[0]: value.split(":")[1] for value in (j1 - j2)})
-    result2 = unflatten({value.split(":")[0]: value.split(":")[1] for value in (j2 - j1)})
+    j1 = {f"{key}{DELIM}{value}" for key, value in json_1_data.items()}
+    j2 = {f"{key}{DELIM}{value}" for key, value in json_2_data.items()}
+    result = unflatten({value.split(DELIM)[0]: value.split(DELIM)[1] for value in (j1 - j2)})
+    result2 = unflatten({value.split(DELIM)[0]: value.split(DELIM)[1] for value in (j2 - j1)})
     return {str(file_1): result, str(file_2): result2}
 
 
@@ -131,7 +134,20 @@ def set_excluded_fields(preset: str) -> Tuple[Set[str], List[str]]:
         excluded.extend(["metadata.timestamp", "serialNumber",
                          "metadata.tools.components.[].version",
                          "metadata.tools.components.[].purl",
-                         "metadata.tools.components.[].bom-ref"])
+                         "metadata.tools.components.[].bom-ref",
+                         "components.[].properties",
+                         "components.[].evidence"
+                         ])
+        sort_fields.extend(["url", "content", "ref", "name", "value"])
+    elif preset == "cdxgen-minimal":
+        excluded.extend(["metadata.timestamp", "serialNumber",
+                         "metadata.tools.components.[].version",
+                         "metadata.tools.components.[].purl",
+                         "metadata.tools.components.[].bom-ref",
+                         "components.[].properties",
+                         "components.[].evidence",
+                         "components.[].licenses"
+                         ])
         sort_fields.extend(["url", "content", "ref", "name", "value"])
     return set(excluded), sort_fields
 
@@ -155,7 +171,7 @@ def sort_list(lst: List, sort_keys: List[str]) -> List:
     if isinstance(lst[0], dict):
         if sort_key := get_sort_key(lst[0], sort_keys):
             return sorted(lst, key=lambda x: x[sort_key])
-        logging.warning("No key(s) specified for sorting. Cannot sort list of dictionaries.")
+        logging.debug("No key(s) specified for sorting. Cannot sort list of dictionaries.")
         return lst
     if isinstance(lst[0], (str, int)):
         lst.sort()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "custom-json-diff"
-version = "0.2.0"
+version = "0.4.0"
 description = "Custom JSON diff tool"
 authors = [
   { name = "Caroline Russell", email = "caroline@appthreat.dev" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "custom-json-diff"
-version = "0.4.0"
+version = "0.3.0"
 description = "Custom JSON diff tool"
 authors = [
   { name = "Caroline Russell", email = "caroline@appthreat.dev" },


### PR DESCRIPTION
The values for bom-ref, purl were getting cut-off when using `:` as the delimiter. This replaces it with another string `|>`

Added cdxgen-minimal profile to ignore licenses. pypi verified publisher is also setup, so feel free to release this.