### PR TITLE
Restore access to exclude to bom-diff, options bugfix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,11 @@ ignore in the comparison and sorts all fields.
 ## CLI Usage
 
 ```
-usage: custom-json-diff [-h] [-v] -i INPUT INPUT [-o OUTPUT] [-c CONFIG] {bom-diff,json-diff} ...
+usage: custom-json-diff [-h] [-v] -i INPUT INPUT [-o OUTPUT] [-c CONFIG] [-x EXCLUDE [EXCLUDE ...]] {bom-diff} ...
 
 positional arguments:
-  {bom-diff,json-diff}  subcommand help
+  {bom-diff}            subcommand help
     bom-diff            compare CycloneDX BOMs
-    json-diff           compare two JSON files
 
 options:
   -h, --help            show this help message and exit
@@ -29,6 +28,8 @@ options:
                         Export JSON of differences to this file.
   -c CONFIG, --config-file CONFIG
                         Import TOML configuration file (overrides commandline options).
+  -x EXCLUDE [EXCLUDE ...], --exclude EXCLUDE [EXCLUDE ...]
+                        Exclude field(s) from comparison.
 
 ```
 
@@ -49,52 +50,6 @@ options:
                         Include properties/evidence/licenses/hashes in comparison (list which with space inbetween).
 ```
 
-json-diff usage
-```
-usage: cjd json-diff [-h] [-x EXCLUDE [EXCLUDE ...]]
-
-options:
-  -h, --help            show this help message and exit
-  -x EXCLUDE [EXCLUDE ...], --exclude EXCLUDE [EXCLUDE ...]
-                        Exclude field(s) from comparison.
-```
-
-## Specifying fields to exclude
-
-To exclude fields from comparison, use the `-x` or `--exclude` flag and specify the field name(s) 
-to exclude. The json will be flattened, so fields are specified using dot notation. For example:
-
-```json
-{
-    "field1": {
-        "field2": "value", 
-        "field3": [
-            {"a": "val1", "b": "val2"}, 
-            {"a": "val3", "b": "val4"}
-        ]
-    }
-}
-```
-
-is flattened to:
-```json
-{
-    "field1.field2": "value",
-    "field1.field3.[0].a": "val1",
-    "field1.field3.[0].b": "val2",
-    "field1.field3.[1].a": "val3",
-    "field1.field3.[1].b": "val4"
-}
-```
-
-To exclude field2, you would specify `field1.field2`. To exclude the `a` field in the array of 
-objects, you would specify `field1.field3.[].a` (do NOT include the array index, just do `[]`). 
-Multiple fields may be specified separated by a space. To better understand what your fields should
-be, check out json-flatten, which is the package used for this function.
-
->Note: In the context of BOM diffing, this list is only used for the metadata, not the components, 
-> services, or dependencies.
-
 ## Bom Diff
 
 The bom-diff command compares CycloneDx BOM components, services, and dependencies, as well as data 
@@ -106,6 +61,10 @@ for inclusion using `bom-diff --include-extra` and whichever field(s) you wish t
 - evidence
 - licenses
 - hashes
+- externalReferences
+
+You can use the -x --exclude switch before the bom-diff command to exclude any of these 
+(see [Specifying fields to exclude](#specifying-fields-to-exclude) ).
 
 Default included fields:
 
@@ -141,6 +100,39 @@ fields included by default.
 
 The --components-only option only analyzes components, not services, dependencies, or other data.
 
+## Specifying fields to exclude
+
+To exclude fields from comparison, use the `-x` or `--exclude` flag and specify the field name(s) 
+to exclude. The json will be flattened, so fields are specified using dot notation. For example:
+
+```json
+{
+    "field1": {
+        "field2": "value", 
+        "field3": [
+            {"a": "val1", "b": "val2"}, 
+            {"a": "val3", "b": "val4"}
+        ]
+    }
+}
+```
+
+is flattened to:
+```json
+{
+    "field1.field2": "value",
+    "field1.field3.[0].a": "val1",
+    "field1.field3.[0].b": "val2",
+    "field1.field3.[1].a": "val3",
+    "field1.field3.[1].b": "val4"
+}
+```
+
+To exclude field2, you would specify `field1.field2`. To exclude the `a` field in the array of 
+objects, you would specify `field1.field3.[].a` (do NOT include the array index, just do `[]`). 
+Multiple fields may be specified separated by a space. To better understand what your fields should
+be, check out json-flatten, which is the package used for this function.
+
 ## Sorting
 
 custom-json-diff will sort the imported JSON alphabetically. If your JSON document contains arrays 
@@ -158,6 +150,6 @@ sort_keys = ["url", "content", "ref", "name", "value"]
 allow_new_data = false
 allow_new_versions = true
 components_only = false
-include_extra = ["licenses", "properties", "hashes", "evidence"]
+include_extra = ["licenses", "properties", "hashes", "evidence", "externalReferences"]
 report_template = "custom_json_diff/bom_diff_template.j2"
 ```

--- a/custom_json_diff/cli.py
+++ b/custom_json_diff/cli.py
@@ -84,13 +84,12 @@ def build_args() -> argparse.Namespace:
     parser_bom_diff.add_argument(
         "--include-extra",
         action="store",
-        help="Include properties/evidence/licenses/hashes (list which with space inbetween).",
+        help="Include properties/evidence/licenses/hashes/externalReferences (list which with space inbetween).",
         default=[],
         dest="include",
         nargs="+",
     )
-    parser_json_diff = subparsers.add_parser("json-diff", help="compare two JSON files")
-    parser_json_diff.add_argument(
+    parser.add_argument(
         "-x",
         "--exclude",
         action="store",

--- a/custom_json_diff/custom_diff.py
+++ b/custom_json_diff/custom_diff.py
@@ -3,6 +3,7 @@ import logging
 import os
 import re
 import sys
+from copy import deepcopy
 from typing import Dict, List, Set, Tuple
 
 from jinja2 import Environment
@@ -23,8 +24,9 @@ def check_regex(regex_keys: Set[re.Pattern], key: str) -> bool:
 
 
 def compare_dicts(options: Options) -> Tuple[int, FlatDicts | BomDicts, FlatDicts | BomDicts]:
+    options2 = deepcopy(options)
     json_1_data = load_json(options.file_1, options)
-    json_2_data = load_json(options.file_2, options)
+    json_2_data = load_json(options.file_2, options2)
     if json_1_data == json_2_data:
         return 0, json_1_data, json_2_data
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "custom-json-diff"
-version = "1.0.0"
+version = "1.1.0"
 description = "Custom JSON and CycloneDx BOM diffing and comparison tool."
 authors = [
   { name = "Caroline Russell", email = "caroline@appthreat.dev" },

--- a/test/test_bom_diff.py
+++ b/test/test_bom_diff.py
@@ -7,30 +7,6 @@ from custom_json_diff.custom_diff_classes import BomComponent, BomDicts, Options
 
 
 @pytest.fixture
-def java_1_bom():
-    options = Options(file_1="test/sbom-java.json", file_2="test/sbom-java2.json", bom_diff=True, include=["hashes", "evidence", "licenses", "properties"])
-    return load_json("test/sbom-java.json", options)
-
-
-@pytest.fixture
-def java_2_bom():
-    options = Options(file_1="test/sbom-java.json", file_2="test/sbom-java2.json", bom_diff=True, include=["hashes", "evidence", "licenses", "properties"])
-    return load_json("test/sbom-java2.json", options)
-
-
-@pytest.fixture
-def python_1_bom():
-    options = Options(file_1="test/sbom-python.json", file_2="test/sbom-python2.json", bom_diff=True, include=["licenses", "hashes", "evidence", "properties"])
-    return load_json("test/sbom-python.json", options)
-
-
-@pytest.fixture
-def python_2_bom():
-    options = Options(file_1="test/sbom-python.json", file_2="test/sbom-python2.json", bom_diff=True, include=["licenses", "hashes", "evidence", "properties"])
-    return load_json("test/sbom-python2.json", options)
-
-
-@pytest.fixture
 def options_1():
     return Options(file_1="test/sbom-java.json", file_2="test/sbom-java2.json", bom_diff=True, include=["hashes", "evidence", "licenses"])
 
@@ -43,6 +19,7 @@ def options_2():
 @pytest.fixture
 def options_3():
     return Options(file_1="bom_1.json", file_2="bom_2.json", bom_diff=True, allow_new_data=True)
+
 
 @pytest.fixture
 def bom_dicts_1():
@@ -186,21 +163,92 @@ def bom_dicts_6():
 
 
 @pytest.fixture
+def bom_dicts_7():
+    options = Options(file_1="bom_1.json", file_2="bom_2.json",
+                      bom_diff=True, allow_new_data=True, allow_new_versions=True)
+    bom_dicts = BomDicts(options, "bom_1.json", {}, {})
+    bom_dicts.components = [
+    BomComponent({
+      "bom-ref": "pkg:pypi/requests@2.31.0",
+      "evidence": {
+        "identity": {
+          "confidence": 0.8,
+          "field": "purl",
+          "methods": [
+            {
+              "confidence": 0.8,
+              "technique": "manifest-analysis",
+              "value": "/home/runner/work/src_repos/python/django-goat/requirements_tests.txt"
+            }
+          ]
+        }
+      },
+      "group": "",
+      "name": "requests",
+      "properties": [
+        {
+          "name": "SrcFile",
+          "value": "/home/runner/work/src_repos/python/django-goat/requirements_tests.txt"
+        }
+      ],
+      "purl": "pkg:pypi/requests@2.31.0",
+      "type": "library",
+      "version": "2.31.0"
+    }, options),
+]
+    return bom_dicts
+
+
+@pytest.fixture
+def bom_dicts_8():
+    options = Options(file_1="bom_1.json", file_2="bom_2.json",
+                      bom_diff=True, allow_new_data=True, allow_new_versions=True)
+    bom_dicts = BomDicts(options, "bom_2.json", {}, {})
+    bom_dicts.components = [
+    BomComponent({
+      "bom-ref": "pkg:pypi/requests@2.32.3",
+      "evidence": {
+        "identity": {
+          "confidence": 0.8,
+          "field": "purl",
+          "methods": [
+            {
+              "confidence": 0.8,
+              "technique": "manifest-analysis",
+              "value": "/home/runner/work/src_repos/python/django-goat/requirements_tests.txt"
+            }
+          ]
+        }
+      },
+      "group": "",
+      "name": "requests",
+      "properties": [
+        {
+          "name": "SrcFile",
+          "value": "/home/runner/work/src_repos/python/django-goat/requirements_tests.txt"
+        }
+      ],
+      "purl": "pkg:pypi/requests@2.32.3",
+      "type": "library",
+      "version": "2.32.3"
+    }, options),
+]
+    return bom_dicts
+
+
+@pytest.fixture
 def results():
     with open("test/test_data.json", "r", encoding="utf-8") as f:
         return json.load(f)
 
 
-def test_bom_diff(java_1_bom, java_2_bom, python_1_bom, python_2_bom, results, options_1, options_2):
+def test_bom_diff(results, options_1):
     result, j1, j2 = compare_dicts(options_1)
     result_summary = perform_bom_diff(j1, j2)
     assert result_summary == results["result_4"]
-    result, p1, p2 = compare_dicts(options_2)
-    result_summary2 = perform_bom_diff(p1, p2)
-    assert result_summary2 == results["result_5"]
 
 
-def test_bom_diff_options(results, bom_dicts_1, bom_dicts_2, bom_dicts_3, bom_dicts_4, bom_dicts_5, bom_dicts_6):
+def test_bom_diff_options(results, bom_dicts_1, bom_dicts_2, bom_dicts_3, bom_dicts_4, bom_dicts_5, bom_dicts_6, bom_dicts_7, bom_dicts_8):
     # test --allow-new-data
     result_summary = perform_bom_diff(bom_dicts_1, bom_dicts_2)
     assert result_summary == results["result_1"]
@@ -210,5 +258,9 @@ def test_bom_diff_options(results, bom_dicts_1, bom_dicts_2, bom_dicts_3, bom_di
     assert result_summary == results["result_2"]
 
     # test --allow-new-data and --allow-new-versions
+    result_summary = perform_bom_diff(bom_dicts_7, bom_dicts_8)
+    assert result_summary == results["result_5"]
+
     result_summary = perform_bom_diff(bom_dicts_5, bom_dicts_6)
     assert result_summary == results["result_3"]
+

--- a/test/test_data.json
+++ b/test/test_data.json
@@ -1,1 +1,3623 @@
-{"result_1": {"common_summary": {"components": {"libraries": [], "frameworks": [{"bom-ref": "pkg:maven/org.springframework.cloud/spring-cloud-starter-config@2.0.0.RELEASE?type=jar", "description": "Spring Cloud Starter", "group": "org.springframework.cloud", "name": "spring-cloud-starter-config", "publisher": "Pivotal Software, Inc.", "purl": "pkg:maven/org.springframework.cloud/spring-cloud-starter-config@2.0.0.RELEASE?type=jar", "scope": "required", "type": "framework", "version": "2.0.0.RELEASE"}], "applications": [], "other_types": []}, "misc_data": {}}, "diff_summary": {"bom_2.json": {"components": {"libraries": [{"bom-ref": "pkg:maven/joda-time/joda-time@2.9.9?type=jar", "description": "", "group": "joda-time", "name": "joda-time", "publisher": "Joda.org", "purl": "pkg:maven/joda-time/joda-time@2.9.9?type=jar", "scope": "required", "type": "library", "version": "2.9.9"}], "frameworks": [], "applications": [], "other_types": []}, "misc_data": {}}, "bom_1.json": {"components": {"libraries": [{"bom-ref": "pkg:maven/joda-time/joda-time@2.9.9?type=jar", "description": "Date and time library to replace JDK date handling", "group": "joda-time", "name": "joda-time", "publisher": "Joda.org", "purl": "pkg:maven/joda-time/joda-time@2.9.9?type=jar", "scope": "required", "type": "library", "version": "2.9.9"}], "frameworks": [], "applications": [], "other_types": []}, "misc_data": {}}}}, "result_10": {"bomFormat": "CycloneDX", "components": [{"bom-ref": "pkg:pypi/jinja2@2.11.3", "group": "", "name": "Jinja2", "purl": "pkg:pypi/jinja2@2.11.3", "type": "library", "version": "2.10.2"}, {"bom-ref": "pkg:pypi/markupsafe@1.1.1", "group": "", "name": "MarkupSafe", "purl": "pkg:pypi/markupsafe@1.1.1", "type": "library", "version": "1.5.1"}, {"bom-ref": "pkg:pypi/werkzeug@1.0.1", "group": "", "name": "Werkzeug", "purl": "pkg:pypi/werkzeug@1.0.1", "type": "library", "version": "1.0.1"}, {"bom-ref": "pkg:github/actions/checkout@v2", "group": "actions", "name": "checkout", "purl": "pkg:github/actions/checkout@v2", "type": "application", "version": "v2"}, {"bom-ref": "pkg:pypi/click@7.1.2", "group": "", "name": "click", "purl": "pkg:pypi/click@7.1.2", "type": "library", "version": "7.1.2"}, {"bom-ref": "pkg:pypi/flask@1.1.2", "group": "", "name": "flask", "purl": "pkg:pypi/flask@1.1.2", "type": "framework", "version": "1.1.2"}, {"bom-ref": "pkg:pypi/itsdangerous@1.1.0", "group": "", "name": "itsdangerous", "purl": "pkg:pypi/itsdangerous@1.1.0", "type": "library", "version": "1.1.0"}, {"bom-ref": "pkg:github/actions/setup-python@v2", "group": "actions", "name": "setup-python", "purl": "pkg:github/actions/setup-python@v2", "type": "application", "version": "v2"}], "dependencies": [{"dependsOn": [], "ref": "pkg:pypi/click@7.1.2"}, {"dependsOn": ["pkg:pypi/flask@1.1.2"], "ref": "pkg:pypi/flask-webgoat@latest"}, {"dependsOn": ["pkg:pypi/click@7.1.2", "pkg:pypi/itsdangerous@1.1.0", "pkg:pypi/jinja2@2.11.3", "pkg:pypi/werkzeug@1.0.1"], "ref": "pkg:pypi/flask@1.1.2"}, {"dependsOn": [], "ref": "pkg:pypi/itsdangerous@1.1.0"}, {"dependsOn": ["pkg:pypi/markupsafe@1.1.1"], "ref": "pkg:pypi/jinja2@2.11.3"}, {"dependsOn": [], "ref": "pkg:pypi/markupsafe@1.1.1"}, {"dependsOn": [], "ref": "pkg:pypi/werkzeug@1.0.1"}], "metadata": {"authors": [{"name": "OWASP Foundation"}], "component": {"bom-ref": "pkg:gem/flask-webgoat@latest", "group": "", "name": "flask-webgoat", "purl": "pkg:gem/flask-webgoat@latest", "type": "application", "version": "latest"}, "lifecycles": [{"phase": "build"}], "tools": {"components": [{"author": "OWASP Foundation", "group": "@cyclonedx", "name": "cdxgen", "publisher": "OWASP Foundation", "type": "application"}]}}, "services": [{"authenticated": false, "endpoints": ["/message", "/grep_processes"], "name": "actions-service"}, {"authenticated": false, "endpoints": ["/login", "/login_and_redirect"], "name": "auth-service"}, {"authenticated": false, "endpoints": ["/status", "/ping"], "name": "status-service"}, {"authenticated": false, "endpoints": ["/search"], "name": "ui-service"}, {"authenticated": false, "endpoints": ["/create_user"], "name": "users-service"}], "specVersion": "1.5", "version": 2}, "result_11": {"components": [{"version": "2.11.3"}, {"bom-ref": "pkg:pypi/markupsafe@1.1.1", "name": "MarkupSafe", "purl": "pkg:pypi/markupsafe@1.1.1", "version": "1.1.1"}, {"version": "1.0.1"}, {"bom-ref": "pkg:pypi/click@7.1.2", "name": "click", "purl": "pkg:pypi/click@7.1.2", "version": "7.1.2"}, {"bom-ref": "pkg:pypi/itsdangerous@1.1.0", "name": "itsdangerous", "purl": "pkg:pypi/itsdangerous@1.1.0", "version": "1.1.0"}], "dependencies": [{"ref": "pkg:pypi/click@7.1.2"}, {"dependsOn": ["pkg:pypi/click@7.1.2", "pkg:pypi/itsdangerous@1.1.0", "pkg:pypi/jinja2@2.11.3", "pkg:pypi/werkzeug@1.0.1"], "ref": "pkg:pypi/flask@1.1.2"}, {"ref": "pkg:pypi/itsdangerous@1.1.0"}], "services": [{"endpoints": ["/create_user"], "name": "users-service"}]}, "result_2": {"common_summary": {"components": {"libraries": [], "frameworks": [{"bom-ref": "pkg:maven/org.springframework.cloud/spring-cloud-starter-config@2.3.0.RELEASE?type=jar", "description": "Spring Cloud Starter", "group": "org.springframework.cloud", "name": "spring-cloud-starter-config", "publisher": "Pivotal Software, Inc.", "purl": "pkg:maven/org.springframework.cloud/spring-cloud-starter-config@2.3.0.RELEASE?type=jar", "scope": "required", "type": "framework", "version": "2.3.0.RELEASE"}], "applications": [], "other_types": []}}, "diff_summary": {"bom_2.json": {"components": {"libraries": [{"bom-ref": "pkg:maven/joda-time/joda-time@2.8.9?type=jar", "description": "Date and time library to replace JDK date handling", "group": "joda-time", "name": "joda-time", "publisher": "Joda.org", "purl": "pkg:maven/joda-time/joda-time@2.8.9?type=jar", "scope": "required", "type": "library", "version": "2.8.9"}], "frameworks": [], "applications": [], "other_types": []}}, "bom_1.json": {"components": {"libraries": [{"bom-ref": "pkg:maven/joda-time/joda-time@2.9.9?type=jar", "description": "Date and time library to replace JDK date handling", "group": "joda-time", "name": "joda-time", "publisher": "Joda.org", "purl": "pkg:maven/joda-time/joda-time@2.9.9?type=jar", "scope": "required", "type": "library", "version": "2.9.9"}], "frameworks": [], "applications": [], "other_types": []}}}}, "result_3": {"common_summary": {"components": {"libraries": [], "frameworks": [], "applications": [{"bom-ref": "pkg:github/actions/checkout@v2", "group": "actions", "name": "checkout", "purl": "pkg:github/actions/checkout@v2", "type": "application", "version": "v2"}], "other_types": []}, "misc_data": {}}, "diff_summary": {"bom_2.json": {"components": {"libraries": [{"bom-ref": "pkg:pypi/werkzeug@1.1.1", "group": "", "name": "Werkzeug", "purl": "pkg:pypi/werkzeug@1.1.1", "type": "library", "version": "1.1.1"}], "frameworks": [{"bom-ref": "pkg:pypi/flask@1.1.0", "group": "", "name": "flask", "purl": "pkg:pypi/flask@1.1.0", "type": "framework", "version": "1.1.0"}], "applications": [{"bom-ref": "pkg:github/actions/setup-python@v2", "group": "", "name": "setup-python", "purl": "pkg:github/actions/setup-python@v2", "type": "application", "version": "v2"}], "other_types": []}, "misc_data": {}}, "bom_1.json": {"components": {"libraries": [{"bom-ref": "pkg:pypi/werkzeug@1.0.1", "group": "", "name": "Werkzeug", "purl": "pkg:pypi/werkzeug@1.0.1", "type": "library", "version": "1.0.1"}], "frameworks": [{"bom-ref": "pkg:pypi/flask@1.1.2", "group": "", "name": "flask", "purl": "pkg:pypi/flask@1.1.2", "type": "framework", "version": "1.1.2"}], "applications": [{"bom-ref": "pkg:github/actions/setup-python@v2", "group": "actions", "name": "setup-python", "purl": "pkg:github/actions/setup-python@v2", "type": "application", "version": "v2"}], "other_types": []}, "misc_data": {}}}}, "result_4": {"common_summary": {"components": {"libraries": [{"bom-ref": "pkg:maven/org.aspectj/aspectjweaver@1.8.13?type=jar", "description": "The AspectJ weaver introduces advices to java classes", "evidence": {"identity": {"confidence": 0.8, "field": "purl", "methods": [{"confidence": 0.8, "technique": "binary-analysis", "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\org\\aspectj\\aspectjweaver\\1.8.13\\aspectjweaver-1.8.13.jar"}]}}, "group": "org.aspectj", "hashes": [{"alg": "MD5", "content": "4a95811a5b41a038a359c05189de9829"}, {"alg": "SHA-1", "content": "ad94df2a28d658a40dc27bbaff6a1ce5fbf04e9b"}, {"alg": "SHA-256", "content": "965d0928b0e07dcedb67f0d0a48653d36a6cff257e3270cb28ea48fef6c30a27"}, {"alg": "SHA-512", "content": "be2b21636f7e6786c9c3c50684e522520d6bc0580ce49ff8a9c0fbe422568acbb91fd70dde63a3624098ba10d4e3892f2de0ffaa05f595278d2726b44e6aa576"}, {"alg": "SHA-384", "content": "a7aa2b3cbd2abc4264f69e97e70e202c24d8fa2c67376cd1c16731fecee57b518cd41c45c0288e036100c6a7c53750ec"}, {"alg": "SHA3-384", "content": "71b931c9517a44ec80139384581067a8d2ebb642d9bae8ce2ad785e6479a1e380ab9d5d5720582bd7d9e2d33c7322571"}, {"alg": "SHA3-256", "content": "8fc704392325ca3d4597055a9e7780b7e2ada5bf63ca1d60a9bbfbc2c6d8f1df"}, {"alg": "SHA3-512", "content": "e5d1354f72fcaf1018ff248554491077e8037c116ee6f66d98f49f290f17417bb0d73f18775f00717978755ea44533c95d13011217531d065ac3f15b9c582d7a"}], "licenses": [{"license": {"id": "EPL-1.0"}}], "name": "aspectjweaver", "purl": "pkg:maven/org.aspectj/aspectjweaver@1.8.13?type=jar", "scope": "required", "type": "library", "version": "1.8.13"}, {"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.9.6?type=jar", "description": "Core Jackson processing abstractions (aka Streaming API), implementation for JSON", "evidence": {"identity": {"confidence": 0.8, "field": "purl", "methods": [{"confidence": 0.8, "technique": "binary-analysis", "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\com\\fasterxml\\jackson\\core\\jackson-core\\2.9.6\\jackson-core-2.9.6.jar"}]}}, "group": "com.fasterxml.jackson.core", "hashes": [{"alg": "MD5", "content": "f3cf83b839fac92307cad542c2ded5c4"}, {"alg": "SHA-1", "content": "4e393793c37c77e042ccc7be5a914ae39251b365"}, {"alg": "SHA-256", "content": "fab8746aedd6427788ee390ea04d438ec141bff7eb3476f8bdd5d9110fb2718a"}, {"alg": "SHA-512", "content": "a1b9b68b67d442a47e36b46b37b6b0ad7a10c547a1cf7adb4705baec77356e1080049d310b3b530f66bbd3c0ed05cfe43c041d6ef4ffbbc6731149624df4e699"}, {"alg": "SHA-384", "content": "59f87a260de53f8ddabe35749cd8abc71e52ebfeacd51b1e68363fe4bf72e632a7ea3648340969e8fdb0eb90d994fff4"}, {"alg": "SHA3-384", "content": "626fc0c5049dde3d55e7b47a935e735bd0dd4aed80d22ba5ec708d581c710702a4a2f4963a1d7870692a77e05d67fd75"}, {"alg": "SHA3-256", "content": "243fdbf974b456d3d96ac5c0d018c3ff2ba6f8dedeea5510da8eb851f2026efb"}, {"alg": "SHA3-512", "content": "6944f9effea908ae8564a7a1a951a9c7b6e27e7cc978eac30fb43ddef0870103f669065d4b0df7293d5d541f9bf9e04b0cebbf26fdf0159d1dffb6fa465bc64f"}], "licenses": [{"license": {"id": "Apache-2.0"}}], "name": "jackson-core", "publisher": "FasterXML", "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.9.6?type=jar", "scope": "required", "type": "library", "version": "2.9.6"}], "frameworks": [{"bom-ref": "pkg:maven/org.bouncycastle/bcpkix-jdk15on@1.56?type=jar", "description": "The Bouncy Castle Java APIs for CMS, PKCS, EAC, TSP, CMP, CRMF, OCSP, and certificate generation. This jar contains APIs for JDK 1.5 to JDK 1.8. The APIs can be used in conjunction with a JCE/JCA provider such as the one provided with the Bouncy Castle Cryptography APIs.", "evidence": {"identity": {"confidence": 0.8, "field": "purl", "methods": [{"confidence": 0.8, "technique": "binary-analysis", "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\org\\bouncycastle\\bcpkix-jdk15on\\1.56\\bcpkix-jdk15on-1.56.jar"}]}}, "group": "org.bouncycastle", "hashes": [{"alg": "MD5", "content": "17b2b704b3ad9b36a6fca1ace60a2a06"}, {"alg": "SHA-1", "content": "4648af70268b6fdb24674fb1fd7c1fcc73db1231"}, {"alg": "SHA-256", "content": "7043dee4e9e7175e93e0b36f45b1ec1ecb893c5f755667e8b916eb8dd201c6ca"}, {"alg": "SHA-512", "content": "6cbc73005b662440c395d81d44d0f52a3e20550f64be3d4fe413c344257c6ef31f8080421b247273f8be42e724de370b1f1b2f0dae58a47010ef4c890d8cf5b8"}, {"alg": "SHA-384", "content": "8147d3692b03ac84ccdd20f8ff7f3d319583434ad1a0178ab31d6433a3ed11c6e05967b26bbaf0420f400a32fb5941c5"}, {"alg": "SHA3-384", "content": "899934416d5f5c3cfe0377b41d1403730c760b6d9edec6079e73a70ec8b92616055c37fb1fee3b227a6dae360cd9cc65"}, {"alg": "SHA3-256", "content": "e57c428533d3222b66f93c6bd530ee3bd0e4584c32d5ad50424072f6e8de2d98"}, {"alg": "SHA3-512", "content": "a6f07a263da0a69665d916d9b41f42d74061630c5ff83e8c407fa3b9aa47708c23a0a3c3c2b9f953af66b60374556c8e89eed2bb7ff3176fc4f603f957f0fffa"}], "licenses": [{"license": {"name": "Bouncy Castle Licence", "url": "http://www.bouncycastle.org/licence.html"}}], "name": "bcpkix-jdk15on", "purl": "pkg:maven/org.bouncycastle/bcpkix-jdk15on@1.56?type=jar", "scope": "required", "type": "framework", "version": "1.56"}, {"bom-ref": "pkg:maven/org.springframework.cloud/spring-cloud-context@2.0.0.RELEASE?type=jar", "description": "Spring Cloud Context", "evidence": {"identity": {"confidence": 0.8, "field": "purl", "methods": [{"confidence": 0.8, "technique": "binary-analysis", "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\org\\springframework\\cloud\\spring-cloud-context\\2.0.0.RELEASE\\spring-cloud-context-2.0.0.RELEASE.jar"}]}, "occurrences": [{"location": "notification-service\\src\\main\\java\\com\\piggymetrics\\notification\\service\\EmailServiceImpl.java#22"}]}, "group": "org.springframework.cloud", "hashes": [{"alg": "MD5", "content": "e7a4e7275f373c6167b7590591c19efd"}, {"alg": "SHA-1", "content": "3f0d28344c0dc74eb8594f3f3dd6f82c687be198"}, {"alg": "SHA-256", "content": "abb111a850530a2d9174939f9ef6424efa4abecf978e5625915aa84ea17bb9fe"}, {"alg": "SHA-512", "content": "c5bcf7518bb6bafc311af1e14db61f5fdcdb56e24658da1481e8806e5ad7c897e4def752b9af7d9df1e6cd998300f4f0881593e4b961827c33777c7cbcb6fb44"}, {"alg": "SHA-384", "content": "96ff50360c1b03d6e225c5975405ce714464cacbbd77896c7841bbf47a14660970b13d2d11d7af1c7396ec4b0e9238e9"}, {"alg": "SHA3-384", "content": "96c8275ce24cc07a8d9311075e667c44a1d9f032993e58be7f9632951a91744b96b118e5db3b0a9882f8d145a7e40f13"}, {"alg": "SHA3-256", "content": "2074e427d7cda1199ef40962370de1dd1b3163c33ce9254a9e0b38a7667dc4bf"}, {"alg": "SHA3-512", "content": "2f05d0c7c31bbac1336e5f37fdcdcdc7bf022a369faaa5c59a2733c8174022a7848492c8faad3fb483c7dce78210cc67465ce68b766b8155652d58d6f206149c"}], "licenses": [{"license": {"id": "Apache-2.0"}}], "name": "spring-cloud-context", "publisher": "Pivotal Software, Inc.", "purl": "pkg:maven/org.springframework.cloud/spring-cloud-context@2.0.0.RELEASE?type=jar", "scope": "required", "type": "framework", "version": "2.0.0.RELEASE"}, {"bom-ref": "pkg:maven/org.springframework.cloud/spring-cloud-starter@2.0.0.RELEASE?type=jar", "description": "Spring Cloud Starter", "evidence": {"identity": {"confidence": 0.8, "field": "purl", "methods": [{"confidence": 0.8, "technique": "binary-analysis", "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\org\\springframework\\cloud\\spring-cloud-starter\\2.0.0.RELEASE\\spring-cloud-starter-2.0.0.RELEASE.jar"}]}}, "group": "org.springframework.cloud", "hashes": [{"alg": "MD5", "content": "4d031dc9879546e189c6c914c19c0542"}, {"alg": "SHA-1", "content": "0247ea27d9483e9806f539f6031af135a6a3645f"}, {"alg": "SHA-256", "content": "670eedd14018f52145cd58de663739657a19e0e1a7ad965cf7e0a99dd37e84e4"}, {"alg": "SHA-512", "content": "8187b1a499b98e9a2e44bdfa3bca5088ee8034bce371c014b5fd4b1c2240f3447562ba74987b3d91552d45e6c2349942342133ab6bc8e2ba4330257ad63b2f3b"}, {"alg": "SHA-384", "content": "a42de307261711df91fd860690834edf0c28144e820ed8c513c3ec606ffc7728d3ff0496272b55944fbcce4ba7c79675"}, {"alg": "SHA3-384", "content": "dba2c320469b2d423fae76fc68a0b57f4d5f7da17f2c7b44c41b7654bbb8395b7e669c538384728e2e65824e8864b501"}, {"alg": "SHA3-256", "content": "d43f97976acafc9bcb47ccece04ef74ab61a6faddfea7ff5cae7c3c1acaedce5"}, {"alg": "SHA3-512", "content": "5dc4e0e8e5f8e8154aeb362d6018a6d6d3507f4b3d60a3cf51d9ae80e17a9b5a300ff26ac1b508e1ab13c569ae572e94c443e4ca1c92edd48771a7fe5287b1bd"}], "licenses": [{"license": {"id": "Apache-2.0"}}], "name": "spring-cloud-starter", "publisher": "Pivotal Software, Inc.", "purl": "pkg:maven/org.springframework.cloud/spring-cloud-starter@2.0.0.RELEASE?type=jar", "scope": "required", "type": "framework", "version": "2.0.0.RELEASE"}, {"bom-ref": "pkg:maven/org.springframework.cloud/spring-cloud-starter-config@2.0.0.RELEASE?type=jar", "description": "Spring Cloud Starter", "evidence": {"identity": {"confidence": 0.8, "field": "purl", "methods": [{"confidence": 0.8, "technique": "binary-analysis", "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\org\\springframework\\cloud\\spring-cloud-starter-config\\2.0.0.RELEASE\\spring-cloud-starter-config-2.0.0.RELEASE.jar"}]}}, "group": "org.springframework.cloud", "hashes": [{"alg": "MD5", "content": "5d514c991ae9344ed41c50b6cce19bdc"}, {"alg": "SHA-1", "content": "42f8c6a92ef1a09239e38a1cf65293ffde1b181c"}, {"alg": "SHA-256", "content": "5342438a378e975b8ecd228eb33f527a96267ab75bd4e5c8a0bbdc729a9f95a9"}, {"alg": "SHA-512", "content": "323078a561ef0cd2ab514801fe8604a3c16b2ae43c1bf92ad32d0abec780e0f9b557a781da1d6a9c56a225e77ef9cca3987246b3f43fbb7a5e2998caab392b8f"}, {"alg": "SHA-384", "content": "d1c7ef45846e4bf3e0b69131d80102d5be8e9413d40a00aebecb4461ef59b06cd52c05ae68777592a9689713b92f64b7"}, {"alg": "SHA3-384", "content": "eb6590405d9ff1dcf6b729bb561230598adf7893d61c1a46c5ae6f65974e3a3550b2b480628b656ea765be6fba9a8102"}, {"alg": "SHA3-256", "content": "77acab1bc1c472b4f2d3dbadab3d278c827a967db51a6ca6d2046e1b6fc469f7"}, {"alg": "SHA3-512", "content": "6736c58d38d47072eb084233062b0ea96b3b0ff66a4c4e8a4c2f3349d07a7091933abf05fda7a7660474520f7bb75c66d2c98fa9c488f98fe452d5dac132483a"}], "licenses": [{"license": {"id": "Apache-2.0"}}], "name": "spring-cloud-starter-config", "publisher": "Pivotal Software, Inc.", "purl": "pkg:maven/org.springframework.cloud/spring-cloud-starter-config@2.0.0.RELEASE?type=jar", "scope": "required", "type": "framework", "version": "2.0.0.RELEASE"}, {"bom-ref": "pkg:maven/org.springframework.security/spring-security-rsa@1.0.5.RELEASE?type=jar", "description": "Spring Security RSA is a small utility library for RSA ciphers. It belongs to the family of Spring Security crypto libraries that handle encoding and decoding text as a general, useful thing to be able to do.", "evidence": {"callstack": {"frames": [{"fullFilename": "auth-service\\src\\main\\java\\com\\piggymetrics\\auth\\config\\WebSecurityConfig.java", "function": "authenticationManagerBean", "line": 38, "module": "com.piggymetrics.auth.config.WebSecurityConfig", "package": "com.piggymetrics.auth.config"}, {"column": 16, "fullFilename": "auth-service\\src\\main\\java\\com\\piggymetrics\\auth\\config\\WebSecurityConfig.java", "function": "authenticationManagerBean", "line": 41, "module": "com.piggymetrics.auth.config.WebSecurityConfig", "package": "com.piggymetrics.auth.config"}, {"column": 16, "fullFilename": "auth-service\\src\\main\\java\\com\\piggymetrics\\auth\\config\\WebSecurityConfig.java", "function": "authenticationManagerBean", "line": 41, "module": "com.piggymetrics.auth.config.WebSecurityConfig", "package": "com.piggymetrics.auth.config"}, {"column": 9, "fullFilename": "auth-service\\src\\main\\java\\com\\piggymetrics\\auth\\config\\WebSecurityConfig.java", "function": "authenticationManagerBean", "line": 41, "module": "com.piggymetrics.auth.config.WebSecurityConfig", "package": "com.piggymetrics.auth.config"}]}, "identity": {"confidence": 0.8, "field": "purl", "methods": [{"confidence": 0.8, "technique": "binary-analysis", "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\org\\springframework\\security\\spring-security-rsa\\1.0.5.RELEASE\\spring-security-rsa-1.0.5.RELEASE.jar"}]}}, "group": "org.springframework.security", "hashes": [{"alg": "MD5", "content": "88d25c857040132ad991af650dcb5e9e"}, {"alg": "SHA-1", "content": "31bd1111ada2f455eb0f492ed09e39deda18ca99"}, {"alg": "SHA-256", "content": "db764286a058f85ac06df00c254afd8d63c618db5abc962a6bdb5f440cb2e5d6"}, {"alg": "SHA-512", "content": "9613e84294a7d0486d6f9529a614526b1b9e37c17c7a1f8c59baa418fe04eb5f09163ef31a7e29b59673bb899bfeaa1d9b99daf91a70dec0a3f761e12da7c284"}, {"alg": "SHA-384", "content": "74af3ef26d098d1c4954e5c4d8cf19391ea1788eaa06cf4d4176d7fd7008d7b34ef594e384c480966cf3e6fd1a57df9e"}, {"alg": "SHA3-384", "content": "ae5b96fd3c5ef3c12bfc91cd6b74fea4d0371ebeed79ff8de1c219b6689ed878c3dde01fb90c34a0163681d234e7a9d2"}, {"alg": "SHA3-256", "content": "cfb4a0c1fee534a26992a7f7adf569b07b5e1190338adf77639afd384c20f2d3"}, {"alg": "SHA3-512", "content": "60338f31c9984f232abb52affe0025bb4f8380a71b754d8f5f686360339985d6015f995299d73a8cf4a9eac743cfc9cc141b9de0c672d4743b2740539b497e0a"}], "licenses": [{"license": {"id": "Apache-2.0"}}], "name": "spring-security-rsa", "publisher": "SpringSource", "purl": "pkg:maven/org.springframework.security/spring-security-rsa@1.0.5.RELEASE?type=jar", "scope": "required", "type": "framework", "version": "1.0.5.RELEASE"}], "applications": [], "other_types": []}, "misc_data": {"bomFormat": "CycloneDX", "metadata": {"authors": [{"name": "OWASP Foundation"}], "component": {"bom-ref": "pkg:maven/com.piggymetrics/turbine-stream-service@0.0.1-SNAPSHOT?type=jar", "description": "Turbine Stream Service", "externalReferences": [{"type": "vcs", "url": "https://github.com/spring-projects/spring-boot/spring-boot-starter-parent/piggymetrics/turbine-stream-service"}, {"type": "website", "url": "https://projects.spring.io/spring-boot/#/spring-boot-starter-parent/piggymetrics/turbine-stream-service"}], "group": "com.piggymetrics", "licenses": [{"license": {"id": "Apache-2.0"}}], "name": "turbine-stream-service", "purl": "pkg:maven/com.piggymetrics/turbine-stream-service@0.0.1-SNAPSHOT?type=jar", "type": "library", "version": "0.0.1-SNAPSHOT"}, "tools": {"components": [{"author": "OWASP Foundation", "group": "@cyclonedx", "name": "cdxgen", "publisher": "OWASP Foundation", "type": "application"}]}}, "specVersion": "1.5", "version": 3}, "services": [{"authenticated": true, "endpoints": ["/uaa/users"], "name": "com-piggymetrics-account-client-AuthServiceClient-createUser-service", "x-trust-boundary": true}, {"endpoints": ["/statistics/{accountName}"], "name": "com-piggymetrics-account-client-StatisticsServiceClient-updateStatistics-service"}, {"endpoints": ["/"], "name": "com-piggymetrics-account-controller-AccountController-createNewAccount-service"}, {"endpoints": ["/current"], "name": "com-piggymetrics-statistics-controller-StatisticsController-getCurrentAccountStatistics-service"}, {"authenticated": true, "endpoints": ["/{accountName}"], "name": "com-piggymetrics-statistics-controller-StatisticsController-getStatisticsByAccountName-service", "x-trust-boundary": true}, {"authenticated": true, "endpoints": ["/{accountName}"], "name": "com-piggymetrics-statistics-controller-StatisticsController-saveAccountStatistics-service", "x-trust-boundary": true}], "dependencies": [{"ref": "pkg:maven/com.piggymetrics/turbine-stream-service@0.0.1-SNAPSHOT?type=jar", "dependsOn": ["pkg:maven/org.springframework.boot/spring-boot-starter-test@2.0.3.RELEASE?type=jar", "pkg:maven/org.springframework.cloud/spring-cloud-starter-config@2.0.0.RELEASE?type=jar", "pkg:maven/org.springframework.cloud/spring-cloud-starter-netflix-eureka-client@2.0.0.RELEASE?type=jar", "pkg:maven/org.springframework.cloud/spring-cloud-starter-netflix-turbine-stream@2.0.0.RELEASE?type=jar", "pkg:maven/org.springframework.cloud/spring-cloud-starter-stream-rabbit@2.0.0.RELEASE?type=jar"]}, {"ref": "pkg:maven/org.springframework.boot/spring-boot-starter@2.0.3.RELEASE?type=jar", "dependsOn": ["pkg:maven/javax.annotation/javax.annotation-api@1.3.2?type=jar", "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.0.3.RELEASE?type=jar", "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.0.3.RELEASE?type=jar", "pkg:maven/org.springframework.boot/spring-boot@2.0.3.RELEASE?type=jar", "pkg:maven/org.springframework/spring-core@5.0.7.RELEASE?type=jar", "pkg:maven/org.yaml/snakeyaml@1.19?type=jar"]}, {"ref": "pkg:maven/org.springframework.cloud/spring-cloud-starter-config@2.0.0.RELEASE?type=jar", "dependsOn": ["pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.6?type=jar", "pkg:maven/org.springframework.cloud/spring-cloud-config-client@2.0.0.RELEASE?type=jar", "pkg:maven/org.springframework.cloud/spring-cloud-starter@2.0.0.RELEASE?type=jar"]}, {"ref": "pkg:maven/org.springframework.cloud/spring-cloud-starter@2.0.0.RELEASE?type=jar", "dependsOn": ["pkg:maven/org.springframework.boot/spring-boot-starter@2.0.3.RELEASE?type=jar", "pkg:maven/org.springframework.cloud/spring-cloud-commons@2.0.0.RELEASE?type=jar", "pkg:maven/org.springframework.cloud/spring-cloud-context@2.0.0.RELEASE?type=jar", "pkg:maven/org.springframework.security/spring-security-rsa@1.0.5.RELEASE?type=jar"]}]}, "diff_summary": {"test/sbom-java2.json": {"components": {"libraries": [{"bom-ref": "pkg:maven/com.piggymetrics/turbine-stream-service@0.0.1-SNAPSHOT?type=jar", "description": "Turbine Stream Service", "group": "com.piggymetrics", "licenses": [{"license": {"id": "Apache-2.0"}}], "name": "turbine-stream-service", "purl": "pkg:maven/com.piggymetrics/turbine-stream-service@0.0.1-SNAPSHOT?type=jar", "type": "library", "version": "0.0.1-SNAPSHOT"}], "frameworks": [{"bom-ref": "pkg:maven/javax.activation/activation@1.1?type=jar", "description": "JavaBeans Activation Framework (JAF) is a standard extension to the Java platform that lets you take advantage of standard services to: determine the type of an arbitrary piece of data; encapsulate access to it; discover the operations available on it; and instantiate the appropriate bean to perform the operation(s).", "evidence": {"identity": {"confidence": 0.8, "field": "purl", "methods": [{"confidence": 0.8, "technique": "binary-analysis", "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\javax\\activation\\activation\\1.1\\activation-1.1.jar"}]}}, "group": "javax.activation", "hashes": [{"alg": "MD5", "content": "8ae38e87cd4f86059c0294a8fe3e0b18"}, {"alg": "SHA-1", "content": "e6cb541461c2834bdea3eb920f1884d1eb508b50"}, {"alg": "SHA-256", "content": "2881c79c9d6ef01c58e62beea13e9d1ac8b8baa16f2fc198ad6e6776defdcdd3"}, {"alg": "SHA-512", "content": "c0ff5bf3ace7acc1b31fcc109cee48d9eb8f025ae15a31dc91eca760933bdb97c93f05d61e95af1e317859d72e5f179f897f5bf3df0e3810f4212d43bacee4bd"}, {"alg": "SHA-384", "content": "c4ee54d80a2e67e819700051d6cfa01a17631c89f942b8690afb601e491f02d7497fe57bd5c70edfb9b444ae8222b846"}, {"alg": "SHA3-384", "content": "de0777d2d1d7aad105defb12aed17ef38abfe89db2449c5243fa3c69304ea24dd8df0881330351d0733313e8f7252814"}, {"alg": "SHA3-256", "content": "5fb94d2742cc3d44abad42c5d61b9c7464a2ef33bc58b4b5b121d49799123460"}, {"alg": "SHA3-512", "content": "c5e37fe3d9c420a9035f1160eb1d396e94f01851c01c6e2f19f19a221bfc484e63f9660c7377f58aa65246b95a9eb799ac4e6798c0b20f658edf00a4435e1efa"}], "licenses": [{"license": {"id": "CDDL-1.0"}}], "name": "activation", "purl": "pkg:maven/javax.activation/activation@1.1?type=jar", "scope": "required", "type": "framework", "version": "1.1"}], "applications": [], "other_types": []}, "misc_data": {}, "dependencies": [{"ref": "pkg:maven/javax.activation/activation@1.1?type=jar", "dependsOn": []}]}, "test/sbom-java.json": {"components": {"libraries": [{"bom-ref": "pkg:maven/commons-jxpath/commons-jxpath@1.3?type=jar", "description": "A Java-based implementation of XPath 1.0 that, in addition to XML processing, can inspect/modify Java object graphs (the library's explicit purpose) and even mixed Java/XML structures.", "evidence": {"identity": {"confidence": 0.8, "field": "purl", "methods": [{"confidence": 0.8, "technique": "binary-analysis", "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\commons-jxpath\\commons-jxpath\\1.3\\commons-jxpath-1.3.jar"}]}}, "group": "commons-jxpath", "hashes": [{"alg": "MD5", "content": "61a9aa8ff43ba10853571d57f724bf88"}, {"alg": "SHA-1", "content": "c22d7d0f0f40eb7059a23cfa61773a416768b137"}, {"alg": "SHA-256", "content": "fcbc0ad917d9d6a73c6df21fac322e00d213ef19cd94815a007c407a8a3ff449"}, {"alg": "SHA-512", "content": "351c5f6af0711a955e5d839551833015956812765e9dc35e78bfd7c99656f1ecec5cf6587469229688340f00c2b5d07917993ccb0809561e0dd35b4ffb074d93"}, {"alg": "SHA-384", "content": "327139dac9f672ffa772480a754ec6c3125a3057faf7911188a34cc52d088770efe8464bb303e2347be7f55303d24493"}, {"alg": "SHA3-384", "content": "b2913b137433bfc2fe78ed57dc44de5737410947e809c0b8bb1d6a83ad333069e41fd97167c20e9fd3a052c2a7dfa9b8"}, {"alg": "SHA3-256", "content": "3bbafe102ece8be037419a214a524f0c52fa0c3455322d3c2633f1c075e9efbc"}, {"alg": "SHA3-512", "content": "e050591ecd10746ffee670e1e95a53afa8b43b01164c3ae581bce9ee0a5410eece3f71d05175486eb4d186de88d5defeebef52730939611951ca1cd50ec978a7"}], "licenses": [{"license": {"id": "Apache-2.0"}}], "name": "commons-jxpath", "publisher": "The Apache Software Foundation", "purl": "pkg:maven/commons-jxpath/commons-jxpath@1.3?type=jar", "scope": "required", "type": "library", "version": "1.3"}, {"bom-ref": "pkg:maven/com.netflix.eureka/eureka-client@1.9.2?type=jar", "description": "eureka-client", "evidence": {"identity": {"confidence": 0.8, "field": "purl", "methods": [{"confidence": 0.8, "technique": "binary-analysis", "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\com\\netflix\\eureka\\eureka-client\\1.9.2\\eureka-client-1.9.2.jar"}]}}, "group": "com.netflix.eureka", "hashes": [{"alg": "MD5", "content": "f1a16ca3654e743409bb60c47eb02f01"}, {"alg": "SHA-1", "content": "47c0b71d8face149833c4958ac7b3b6171861f4c"}, {"alg": "SHA-256", "content": "279fc7616a9c0c904dd11ba53aaeec0790d35511cbda2a81e8606b6c6a13c7f3"}, {"alg": "SHA-512", "content": "3abb8075ff7ece646f8ae62c840a8b79b1163741a41e84a7dd7af939f554c6e2f9057ca901d10fe639b693fb9223a2f74bce00743b421a9263acdb246eeee7cb"}, {"alg": "SHA-384", "content": "99475120ea6b3ca18098f3346fe2a7ca539a472d2110e0aedf96d941403a1f37049df31785d1e4e3257adf44d0a5630a"}, {"alg": "SHA3-384", "content": "b7a195e9f54f4189c8e27624ba44c5ff191ffe977d6e70ffc6d1795a4f4d4d3869d15992e555eed71cb427f744fd3b9b"}, {"alg": "SHA3-256", "content": "2ed92d790b33a71dcc8de331d77bdde3c823ced8521ad0cd6e1f75430fdb04bf"}, {"alg": "SHA3-512", "content": "b0f8d56fa259be87844612709b83ba3611548215d405ecd02220a22e1539d2666a5cf37b51ca618291f92dbb007dfd4a6dfa037905bfd0d313b8221cc2605c5b"}], "licenses": [{"license": {"id": "Apache-2.0"}}], "name": "eureka-client", "purl": "pkg:maven/com.netflix.eureka/eureka-client@1.9.2?type=jar", "scope": "required", "type": "library", "version": "1.9.2"}, {"bom-ref": "pkg:maven/com.google.code.gson/gson@2.8.5?type=jar", "description": "Gson JSON library", "evidence": {"identity": {"confidence": 0.8, "field": "purl", "methods": [{"confidence": 0.8, "technique": "binary-analysis", "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\com\\google\\code\\gson\\gson\\2.8.5\\gson-2.8.5.jar"}]}}, "group": "com.google.code.gson", "hashes": [{"alg": "MD5", "content": "089104cb90d8b4e1aa00b1f5faef0742"}, {"alg": "SHA-1", "content": "f645ed69d595b24d4cf8b3fbb64cc505bede8829"}, {"alg": "SHA-256", "content": "233a0149fc365c9f6edbd683cfe266b19bdc773be98eabdaf6b3c924b48e7d81"}, {"alg": "SHA-512", "content": "5dd7214c542a7b93aab3eab0ba13e4ac3d6ddb05c795fb6d3992e21925a98dce87cb186ac67b4d3ad146f96e14d38b3892837eca57a27b4e845aca6d4e4f708a"}, {"alg": "SHA-384", "content": "77f4d6efe8d9cf78b72f34e439035d266db1b82c9d96e6b78e6c571d4c719bb5f2b78e8377263280c6cc9dffe18b3d16"}, {"alg": "SHA3-384", "content": "953e2eca6de4a05e1cf86a9750aa9f1d10bfd06a15f7eaab4a59716cbec74a7bf6c5f421b1752d487882954daecc5781"}, {"alg": "SHA3-256", "content": "94cde12c15a685a10309653cfef73d14d09b340f1b8f0a9a04267136e9bf2820"}, {"alg": "SHA3-512", "content": "0aed985c19435fb6d5e04a79a7553f56a66814157ac93addcb24f9286321d0063b69ac008501f0e22f691ecb15a50491d3313aee73a745286454817e2f410fe9"}], "licenses": [{"license": {"id": "Apache-2.0"}}], "name": "gson", "purl": "pkg:maven/com.google.code.gson/gson@2.8.5?type=jar", "scope": "required", "type": "library", "version": "2.8.5"}, {"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.9.0?type=jar", "description": "Core annotations used for value types, used by Jackson data binding package.", "evidence": {"identity": {"confidence": 0.8, "field": "purl", "methods": [{"confidence": 0.8, "technique": "binary-analysis", "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\com\\fasterxml\\jackson\\core\\jackson-annotations\\2.9.0\\jackson-annotations-2.9.0.jar"}]}, "occurrences": [{"location": "statistics-service\\src\\main\\java\\com\\piggymetrics\\statistics\\domain\\ExchangeRatesContainer.java#9"}]}, "group": "com.fasterxml.jackson.core", "hashes": [{"alg": "MD5", "content": "c09faa1b063681cf45706c6df50685b6"}, {"alg": "SHA-1", "content": "07c10d545325e3a6e72e06381afe469fd40eb701"}, {"alg": "SHA-256", "content": "45d32ac61ef8a744b464c54c2b3414be571016dd46bfc2bec226761cf7ae457a"}, {"alg": "SHA-512", "content": "266589c36ea544ebca94aecd76ba9dfe88637563b94cf24e46846466b103074c9f95508bfa237c20d0ab9c60bfb6befa2628236dcf7222a69cf1ef9462bcf0b3"}, {"alg": "SHA-384", "content": "36289e4a5d6774c4fc6ed38a632a681759a4bc0389616a79edd22298dbcbe8f1bc7a107f00a9ec76b492d125c890a939"}, {"alg": "SHA3-384", "content": "d575397eff488d8b2e2098f1bcc8c0a7d49a3c0532ecec9c2996709576cf9fffe967f421dab2c4d2e280867efefd71af"}, {"alg": "SHA3-256", "content": "5ad4c52561d43e8f80798256ae39449955b2d34376d3fbb9f354f9fcb61f477a"}, {"alg": "SHA3-512", "content": "8322ba66c29bfa8152a4c6294f6c3350d7a59fce154ba9db8624e369085aae42585addf864f373d250f76e5678b5967ecac79aff9255d96e5c109f310424f208"}], "licenses": [{"license": {"id": "Apache-2.0"}}], "name": "jackson-annotations", "publisher": "FasterXML", "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.9.0?type=jar", "scope": "required", "type": "library", "version": "2.9.0"}, {"bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.6?type=jar", "description": "General data-binding functionality for Jackson: works on core streaming API", "evidence": {"identity": {"confidence": 0.8, "field": "purl", "methods": [{"confidence": 0.8, "technique": "binary-analysis", "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\com\\fasterxml\\jackson\\core\\jackson-databind\\2.9.6\\jackson-databind-2.9.6.jar"}]}, "occurrences": [{"location": "account-service\\src\\test\\java\\com\\piggymetrics\\account\\controller\\AccountControllerTest.java#114"}, {"location": "account-service\\src\\test\\java\\com\\piggymetrics\\account\\controller\\AccountControllerTest.java#118"}, {"location": "account-service\\src\\test\\java\\com\\piggymetrics\\account\\controller\\AccountControllerTest.java#131"}, {"location": "account-service\\src\\test\\java\\com\\piggymetrics\\account\\controller\\AccountControllerTest.java#143"}, {"location": "auth-service\\src\\test\\java\\com\\piggymetrics\\auth\\controller\\UserControllerTest.java#51"}, {"location": "notification-service\\src\\test\\java\\com\\piggymetrics\\notification\\controller\\RecipientControllerTest.java#53"}, {"location": "statistics-service\\src\\test\\java\\com\\piggymetrics\\statistics\\controller\\StatisticsControllerTest.java#114"}]}, "group": "com.fasterxml.jackson.core", "hashes": [{"alg": "MD5", "content": "c6634d654c2df15a987bc37ec8d2b6b2"}, {"alg": "SHA-1", "content": "cfa4f316351a91bfd95cb0644c6a2c95f52db1fc"}, {"alg": "SHA-256", "content": "657e3e979446d61f88432b9c50f0ccd9c1fe4f1c822d533f5572e4c0d172a125"}, {"alg": "SHA-512", "content": "f0861f775e2aebd61df8a39419f959b61019af7b307812b92beb14d7a234edeaf09c054fbb24a1432f4dd0c726b7d2b535bdc3ecb8b3d00b661e01d4d46ec4be"}, {"alg": "SHA-384", "content": "80682058957cb75863d94f0ed223dc69cad95526e41b80d2810bfb04308c6fbd4bf4df90f43edacd8f820d43296b61ea"}, {"alg": "SHA3-384", "content": "a5682de7a39422fde523ad1d6fe2db75a4a390266692362e296115e06e07e515cb6b85598ada103e54031dbefc5ea7f3"}, {"alg": "SHA3-256", "content": "885a3161af0a28a56a7d41631034921b846f9b1b0e02062e0758b17337026bdf"}, {"alg": "SHA3-512", "content": "480f9d8a7e5c2cb7ff981b3e004708dd632f8c472a8da3114486499a15a4bfa21ee4904e4ac5f0d1aef4dccd19fc95ceb1f9f6d5a65ea13ca2a7d9815585f82e"}], "licenses": [{"license": {"id": "Apache-2.0"}}], "name": "jackson-databind", "publisher": "FasterXML", "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.6?type=jar", "scope": "required", "type": "library", "version": "2.9.6"}, {"bom-ref": "pkg:maven/org.codehaus.jettison/jettison@1.3.7?type=jar", "description": "A StAX implementation for JSON.", "evidence": {"identity": {"confidence": 0.8, "field": "purl", "methods": [{"confidence": 0.8, "technique": "binary-analysis", "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\org\\codehaus\\jettison\\jettison\\1.3.7\\jettison-1.3.7.jar"}]}}, "group": "org.codehaus.jettison", "hashes": [{"alg": "MD5", "content": "c1ce879e927ca435da0fd2fd6c8a6b60"}, {"alg": "SHA-1", "content": "7d36a59a0577f11b12088b9e215d6860345b9e1d"}, {"alg": "SHA-256", "content": "b39e77d92f5a682c639c8962980499e6be34b5c9fda7ad4dba3b5fd9e99b5070"}, {"alg": "SHA-512", "content": "1304499b9951cba15f10486a061d91ec91efec7aa039162d5fa3d4effb60596fd1c73152fa46d170bbe065d98718f4c9354403bcee7aa3acd03d7b03aa45eeee"}, {"alg": "SHA-384", "content": "4cf5155094f09370f72e94768d6f1429662fb6dcfe6df00f91d78977d42a61dd62d51f1464d3d79eb7363ded95f53474"}, {"alg": "SHA3-384", "content": "5e88aeeb907a6b304a2125a01b55549633b64ce7a43469eff7fdb82ad9e3dfe2e48696c8fd184b2cec6e6062dd1079eb"}, {"alg": "SHA3-256", "content": "e8c94791fa652fbc24dbd55ce3fb3ad3cc703d576f935a4b4d2710148615cf9c"}, {"alg": "SHA3-512", "content": "c75a5dc446297a1eaac02f36829ea2891ffa5e9a3ca45a888f935d8cd65e6f3cab9c6410b45b36987c23674c243b9d6f0d4371f9efec92b70b92a4355732c329"}], "licenses": [{"license": {"id": "Apache-2.0"}}], "name": "jettison", "purl": "pkg:maven/org.codehaus.jettison/jettison@1.3.7?type=jar", "scope": "required", "type": "library", "version": "1.3.7"}, {"bom-ref": "pkg:maven/joda-time/joda-time@2.9.9?type=jar", "description": "Date and time library to replace JDK date handling", "evidence": {"identity": {"confidence": 0.8, "field": "purl", "methods": [{"confidence": 0.8, "technique": "binary-analysis", "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\joda-time\\joda-time\\2.9.9\\joda-time-2.9.9.jar"}]}}, "group": "joda-time", "hashes": [{"alg": "MD5", "content": "eca438c8cc2b1de38e28d884b7f15dbc"}, {"alg": "SHA-1", "content": "f7b520c458572890807d143670c9b24f4de90897"}, {"alg": "SHA-256", "content": "b049a43c1057942e6acfbece008e4949b2e35d1658d0c8e06f4485397e2fa4e7"}, {"alg": "SHA-512", "content": "3a6749ecd71ee8d5781821c36d77850a810e72ee33757ec4ee9e3d424676dced7eeb955a432f45edb3694dc14dbe1ee4c608545d6a445b29b86979a7c9829384"}, {"alg": "SHA-384", "content": "76fadb1a66e6e6f9780aef2ca6ecfe6e07c0abb0829cc436c0ebf02186ba571219a290ec4bf1b510059594b146d39eff"}, {"alg": "SHA3-384", "content": "9f4b85b886cd0b78b1404522979c0bd150dfe27f01469a17e943d35f5fad2de37fd88f35c0f0d49613c81a6fc0a8cd6b"}, {"alg": "SHA3-256", "content": "22837a75e07c2c56cb3565e324f157f0850f9df62471293af3a77ec2ad456535"}, {"alg": "SHA3-512", "content": "b7f8c9cac6086a5c7d861e5dfa9a42c1191ae17e9d9bfbae5eea2e1f6e25eb084fcb9bdc6bbb7d9c693d423452c9533b1216648793d5ca31675af23d1a0f0397"}], "licenses": [{"license": {"id": "Apache-2.0"}}], "name": "joda-time", "publisher": "Joda.org", "purl": "pkg:maven/joda-time/joda-time@2.9.9?type=jar", "scope": "required", "type": "library", "version": "2.9.9"}, {"bom-ref": "pkg:maven/com.netflix.netflix-commons/netflix-eventbus@0.3.0?type=jar", "description": "netflix-eventbus", "evidence": {"identity": {"confidence": 0.8, "field": "purl", "methods": [{"confidence": 0.8, "technique": "binary-analysis", "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\com\\netflix\\netflix-commons\\netflix-eventbus\\0.3.0\\netflix-eventbus-0.3.0.jar"}]}}, "group": "com.netflix.netflix-commons", "hashes": [{"alg": "MD5", "content": "8ad05394a13f658a67d1e4cbf0359402"}, {"alg": "SHA-1", "content": "3f864adbe81f0849729fcbba3fe693c32be739ea"}, {"alg": "SHA-256", "content": "387bce0906f22c285ed96bcc520a7581d6abbc418b6c3c1e45a4530eb97d94b1"}, {"alg": "SHA-512", "content": "94a6efc1be744e281211f7856037c057863ad67ee1a45bd4cfc1adbb15216a6cb20ba0d54caa26d902f653efe496098b5e71eb5b2c466b10deb94af7559f67a0"}, {"alg": "SHA-384", "content": "192c415c11edbc320d0d7b2f41c485bae7dbc20d9f406d0b05a5d02436a005a72d4dc015190748749ac74314f20c496b"}, {"alg": "SHA3-384", "content": "d8580812de33ef27de8dc91205cf56b2aec19572fcfc7fd49e723ed17e4eb4d853f99627417bd9bd30f1cd7de24b4dcf"}, {"alg": "SHA3-256", "content": "840ce15c01ed37b974b4c5ab4a75d539afb6c43cad90437504d23884864735d5"}, {"alg": "SHA3-512", "content": "13549ecc52b63986900eefd48441f78687a5ac0f89d752752f3c973e7d664607785a6b8850ef7ab6181cc4f90580301cc0a19f2fc694e3f97d9776bd43f416e9"}], "licenses": [{"license": {"id": "Apache-2.0"}}], "name": "netflix-eventbus", "purl": "pkg:maven/com.netflix.netflix-commons/netflix-eventbus@0.3.0?type=jar", "scope": "required", "type": "library", "version": "0.3.0"}, {"bom-ref": "pkg:maven/com.netflix.netflix-commons/netflix-infix@0.3.0?type=jar", "description": "netflix-infix", "evidence": {"identity": {"confidence": 0.8, "field": "purl", "methods": [{"confidence": 0.8, "technique": "binary-analysis", "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\com\\netflix\\netflix-commons\\netflix-infix\\0.3.0\\netflix-infix-0.3.0.jar"}]}}, "group": "com.netflix.netflix-commons", "hashes": [{"alg": "MD5", "content": "3410072887ca26fc0b7e71a7e91f8e2b"}, {"alg": "SHA-1", "content": "acc65969f7367ddd2f1265e0cd7330509ed530dc"}, {"alg": "SHA-256", "content": "7dec45215c262c4f0a42c1f3adb8613788cf43c6ed21274e15c73ea5500d2597"}, {"alg": "SHA-512", "content": "477278c1d16d6753a1a2acdb0edd8189b069db1828dd34d808985b48924257e0971ec190bf6efafb14b962e3e0158f2221c195a83fe9bd38fb1574e6cdbf90d3"}, {"alg": "SHA-384", "content": "185629545fd32a7b890c4318cb7979f0475fa42e54039c80105c4eb20efbe5eabf0338ab59256440fc6366e9bc84d0e4"}, {"alg": "SHA3-384", "content": "7aa7b6c88a89c3324677846543b54b5151d45370d48309a529e492576c64174958f22564ed0d5b88a24d5b0696554326"}, {"alg": "SHA3-256", "content": "14f1ba7c66c7b18a45bb2949f784d9028911bdf80376e1553bd9ed6d15083720"}, {"alg": "SHA3-512", "content": "e0b9054727385449f0d29062959eed8ca5f4dec126b85c82fd04155b136ecdf5a4dc1cb78b837f5ff3b86f72b3241d4507f0d4008f519aced1ff2637eb6df3c5"}], "licenses": [{"license": {"id": "Apache-2.0"}}], "name": "netflix-infix", "purl": "pkg:maven/com.netflix.netflix-commons/netflix-infix@0.3.0?type=jar", "scope": "required", "type": "library", "version": "0.3.0"}, {"bom-ref": "pkg:maven/stax/stax-api@1.0.1?type=jar", "description": "StAX API is the standard java XML processing API defined by JSR-173", "evidence": {"identity": {"confidence": 0.8, "field": "purl", "methods": [{"confidence": 0.8, "technique": "binary-analysis", "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\stax\\stax-api\\1.0.1\\stax-api-1.0.1.jar"}]}}, "group": "stax", "hashes": [{"alg": "MD5", "content": "7d436a53c64490bee564c576babb36b4"}, {"alg": "SHA-1", "content": "49c100caf72d658aca8e58bd74a4ba90fa2b0d70"}, {"alg": "SHA-256", "content": "d1968436fc216c901fb9b82c7e878b50fd1d30091676da95b2edd3a9c0ccf92e"}, {"alg": "SHA-512", "content": "43c24e8dbffa9b932492c8ccf2b91926b2ba3d1d34b5a9671c689bd24d4c220b996708a9667521641d1abbf29404b653755b6f6f3dc0ad0671f5c09db332ea06"}, {"alg": "SHA-384", "content": "2e6c232d3012064dc17e10c2e5b281728a6771eb0d74868e730caf60fe6f96fdd6145759fbbf9d1aa2e07eb1f49764d6"}, {"alg": "SHA3-384", "content": "03ebb8db88d04b7308570c1058aadfb6a81d3d6725b1dd13a049ea984ed1df42d3e0f8163e1229752228cada978fb462"}, {"alg": "SHA3-256", "content": "8173e3e3a0db17b3dbb80c017268858ecda57c819e5b58dbe202bd8087664bb1"}, {"alg": "SHA3-512", "content": "e9a7c234dfeff5d4cabd034a536f31ad5a141e30b0ad2438cf5856dd6c36eeb16c69b8bc1ba3ee6bba91f69cd3cbd450953249f2f0eee0a9a22d49637b575f4d"}], "licenses": [{"license": {"id": "Apache-2.0"}}], "name": "stax-api", "purl": "pkg:maven/stax/stax-api@1.0.1?type=jar", "scope": "required", "type": "library", "version": "1.0.1"}, {"bom-ref": "pkg:maven/org.antlr/stringtemplate@3.2.1?type=jar", "description": "StringTemplate is a java template engine for generating source code, web pages, emails, or any other formatted text output. StringTemplate is particularly good at multi-targeted code generators, multiple site skins, and internationalization/localization. It evolved over years of effort developing jGuru.com. StringTemplate also generates the stringtemplate website: http://www.stringtemplate.org and powers the ANTLR v3 code generator. Its distinguishing characteristic is that unlike other engines, it strictly enforces model-view separation. Strict separation makes websites and code generators more flexible and maintainable; it also provides an excellent defense against malicious template authors. There are currently about 600 StringTemplate source downloads a month.", "evidence": {"identity": {"confidence": 0.8, "field": "purl", "methods": [{"confidence": 0.8, "technique": "binary-analysis", "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\org\\antlr\\stringtemplate\\3.2.1\\stringtemplate-3.2.1.jar"}]}}, "group": "org.antlr", "hashes": [{"alg": "MD5", "content": "b58ca53e518a92a1991eb63b61917582"}, {"alg": "SHA-1", "content": "59ec8083721eae215c6f3caee944c410d2be34de"}, {"alg": "SHA-256", "content": "f66ce72e965e5301cb0f020e54d2ba6ad76feb91b3cbfc30dbbf00c06a6df6d7"}, {"alg": "SHA-512", "content": "47f3cfd91906b527b615fd10d27387aafa9f355aa9c18a86861c975091c39895b711fe514ed1597dabe6af2a2705dfc45bb70fb5e30f5d428a48e0d1b02b7856"}, {"alg": "SHA-384", "content": "a12c2a95e162207835a2a785f2dfccd4b3d9d9b94741d1b3e171ff04699afc920c549425115c63a95c7941ead3909edf"}, {"alg": "SHA3-384", "content": "d9ccd03170058316ea8c98142afbecb7a3b357dda5cd1253c9b57810449048fae7d79e93d5ba74cb901bd765429d8714"}, {"alg": "SHA3-256", "content": "6181e67482392f97de747d04dc11418e54ca77888d1d1f6925563fe6a2c1633b"}, {"alg": "SHA3-512", "content": "e75331f732a6c9e280f04438db65c47aa2efb4b07980ad3ce5e227693b47c5959d87e40590e19552f67dc257cc4f187a35ee112e850a6bda9d9e69bba2dba34c"}], "licenses": [{"license": {"name": "BSD licence", "url": "http://antlr.org/license.html"}}], "name": "stringtemplate", "purl": "pkg:maven/org.antlr/stringtemplate@3.2.1?type=jar", "scope": "required", "type": "library", "version": "3.2.1"}], "frameworks": [{"bom-ref": "pkg:maven/antlr/antlr@2.7.7?type=jar", "description": "A framework for constructing recognizers, compilers, and translators from grammatical descriptions containing Java, C#, C++, or Python actions.", "evidence": {"identity": {"confidence": 0.8, "field": "purl", "methods": [{"confidence": 0.8, "technique": "binary-analysis", "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\antlr\\antlr\\2.7.7\\antlr-2.7.7.jar"}]}}, "group": "antlr", "hashes": [{"alg": "MD5", "content": "f8f1352c52a4c6a500b597596501fc64"}, {"alg": "SHA-1", "content": "83cd2cd674a217ade95a4bb83a8a14f351f48bd0"}, {"alg": "SHA-256", "content": "88fbda4b912596b9f56e8e12e580cc954bacfb51776ecfddd3e18fc1cf56dc4c"}, {"alg": "SHA-512", "content": "311c3115f9f6651d1711c52d1739e25a70f25456cacb9a2cdde7627498c30b13d721133cc75b39462ad18812a82472ef1b3b9d64fab5abb0377c12bf82043a74"}, {"alg": "SHA-384", "content": "2e811e531ce30a2a905d093a00de596cf04406413b60422db8252b46125cadf07b71459cf6ac6da575ec030a9bf05e57"}, {"alg": "SHA3-384", "content": "bdf019332ae8714ef6a3904bb42bb08c1fe4feacf5e6137274884b0377d4e5b5f7aa9fe8e1ef5ca9b3e15f12320fdb67"}, {"alg": "SHA3-256", "content": "babce5c8beb1d5907a7ed6354589e991da7d8d5cbd86c479abfa1e1dfc4d2eb8"}, {"alg": "SHA3-512", "content": "3a8ce565280a157dd6e08fb68c317a4c28616099c56bc4992c38cf74a10a54a89e18e7c45190ce8511360798a87adc92f432382f9d9bdde0d56664b50044b517"}], "licenses": [{"license": {"id": "BSD-3-Clause"}}], "name": "antlr", "purl": "pkg:maven/antlr/antlr@2.7.7?type=jar", "scope": "required", "type": "framework", "version": "2.7.7"}, {"bom-ref": "pkg:maven/org.antlr/antlr-runtime@3.4?type=jar", "description": "A framework for constructing recognizers, compilers, and translators from grammatical descriptions containing Java, C#, C++, or Python actions.", "evidence": {"identity": {"confidence": 0.8, "field": "purl", "methods": [{"confidence": 0.8, "technique": "binary-analysis", "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\org\\antlr\\antlr-runtime\\3.4\\antlr-runtime-3.4.jar"}]}}, "group": "org.antlr", "hashes": [{"alg": "MD5", "content": "0e0318be407e51fdf7ba6777eabfdf73"}, {"alg": "SHA-1", "content": "8f011408269a8e42b8548687e137d8eeb56df4b4"}, {"alg": "SHA-256", "content": "5b7cf53b7b30b034023f58030c8147c433f2bee0fe7dec8fae6bebf3708c5a63"}, {"alg": "SHA-512", "content": "1786aff2df4664483adcb319e64be7b69b643ac9508c3f11796b5aa45b9072b46f53f0a21b2ff7291162afe81506de16161746273e4532ebad75adbd81203f0d"}, {"alg": "SHA-384", "content": "6ee2dcd3cf8366fe6ee18fb87aebe2d162b232c89e0aab417f97fed368cdf652d27db518dc5e71aa2a4aadda2e7f4c7a"}, {"alg": "SHA3-384", "content": "db284c93203cbbec1b22b482a45c70c68e858a90e73b23fae66c1bc53231b0f61c5576fcf51ea0d3a30070428d7dd865"}, {"alg": "SHA3-256", "content": "3f6cf631e9f792a41128400f8690266d915c0588ef85073a6cae73624a155b10"}, {"alg": "SHA3-512", "content": "13d1f73c44e807b36946c21cfd506e91e8cbdf685b770cbc0dcb4e55ec28b5bc91bd90eb7f24ebfd13386a47eccf552dd2a1ab277fccabafdb7a9b40aa9d4fc5"}], "licenses": [], "name": "antlr-runtime", "purl": "pkg:maven/org.antlr/antlr-runtime@3.4?type=jar", "scope": "required", "type": "framework", "version": "3.4"}, {"bom-ref": "pkg:maven/org.bouncycastle/bcprov-jdk15on@1.56?type=jar", "description": "The Bouncy Castle Crypto package is a Java implementation of cryptographic algorithms. This jar contains JCE provider and lightweight API for the Bouncy Castle Cryptography APIs for JDK 1.5 to JDK 1.8.", "evidence": {"identity": {"confidence": 0.8, "field": "purl", "methods": [{"confidence": 0.8, "technique": "binary-analysis", "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\org\\bouncycastle\\bcprov-jdk15on\\1.56\\bcprov-jdk15on-1.56.jar"}]}}, "group": "org.bouncycastle", "hashes": [{"alg": "MD5", "content": "3c1bc7aaf3449308e34296546078d9f7"}, {"alg": "SHA-1", "content": "a153c6f9744a3e9dd6feab5e210e1c9861362ec7"}, {"alg": "SHA-256", "content": "963e1ee14f808ffb99897d848ddcdb28fa91ddda867eb18d303e82728f878349"}, {"alg": "SHA-512", "content": "47e5f73d2b66891cf21412b807481fff4b1a844ff247ba170e7bab25a7f6303cbd5ada22e7382ba20ee344d8cc3a1909a3d255f4b24defe9357523b4a122db68"}, {"alg": "SHA-384", "content": "c9de4efe55d8737d5c84e7253cabe2de7b7d72180ef4c0a645ede19f627d3ebce7c0c4f19e51412b7e0a16d6c6255d32"}, {"alg": "SHA3-384", "content": "ef69f74fbf1f5416c90038f07aad6aa83e60932cf8a31400554e0380c134921ed8638528b4339edd5e8b7d1df4f62a3f"}, {"alg": "SHA3-256", "content": "ab4e77030ace3c79f45602cf94baf81ae18305ae83037c5a37077a752cb5bfab"}, {"alg": "SHA3-512", "content": "24ea4d76cc78baecafd8baeae0e201201463d920c102fe20f8dd29ff307785194dc27323215dd24680b77bbb1e65841f8150f047a3b8f007c9b04f4860b4a181"}], "licenses": [{"license": {"name": "Bouncy Castle Licence", "url": "http://www.bouncycastle.org/licence.html"}}], "name": "bcprov-jdk15on", "purl": "pkg:maven/org.bouncycastle/bcprov-jdk15on@1.56?type=jar", "scope": "required", "type": "framework", "version": "1.56"}, {"bom-ref": "pkg:maven/org.apache.commons/commons-math@2.2?type=jar", "description": "The Math project is a library of lightweight, self-contained mathematics and statistics components addressing the most common practical problems not immediately available in the Java programming language or commons-lang.", "evidence": {"identity": {"confidence": 0.8, "field": "purl", "methods": [{"confidence": 0.8, "technique": "binary-analysis", "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\org\\apache\\commons\\commons-math\\2.2\\commons-math-2.2.jar"}]}}, "group": "org.apache.commons", "hashes": [{"alg": "MD5", "content": "4b65633769a2d3c532c86188648bb380"}, {"alg": "SHA-1", "content": "4877b85d388275f994a5cfc7eceb73a8045d3006"}, {"alg": "SHA-256", "content": "15993bb2a3cf50f3291b40fc980a3166a0984e7b5f1abbe5232151fd94954584"}, {"alg": "SHA-512", "content": "f444ead8d025d92ebacc05a366cdfd6f3c9b9788f36961cc66a4c71846b9e953a586268c23268a7a8b9561159fc38f7478daea8142b3b55fb3a8dea756720ab6"}, {"alg": "SHA-384", "content": "56dde9ba9689a3efae9165010b08469108f4971542809b52facc348a841dbed76d83b5fe218ca24db6d8276f45e39458"}, {"alg": "SHA3-384", "content": "7d71fdb235d8d8c4019164315b6241e893215ee3ed4934a15ccc71bae9154726e8e9ec1ab76daf0e8dec62d0069e806d"}, {"alg": "SHA3-256", "content": "d00d7bef766c466c34e0f624a1ba6ea6a2c1a0a46de81f85e331548d13b5cef0"}, {"alg": "SHA3-512", "content": "67bcc94b3d2ebf1e8d9862ad5c57609e6315e53fb27f9db16be4e1384a6619aee9e7f2d2ef530380e107d9c337cbcd4bb3a21ff4293931cb9bb488f598c63b5c"}], "licenses": [{"license": {"id": "Apache-2.0"}}], "name": "commons-math", "publisher": "The Apache Software Foundation", "purl": "pkg:maven/org.apache.commons/commons-math@2.2?type=jar", "scope": "required", "type": "framework", "version": "2.2"}, {"bom-ref": "pkg:maven/org.springframework/spring-aop@5.0.7.RELEASE?type=jar", "description": "Spring AOP", "evidence": {"identity": {"confidence": 0.8, "field": "purl", "methods": [{"confidence": 0.8, "technique": "binary-analysis", "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\org\\springframework\\spring-aop\\5.0.7.RELEASE\\spring-aop-5.0.7.RELEASE.jar"}]}}, "group": "org.springframework", "hashes": [{"alg": "MD5", "content": "cd592093caba2866661a095786f1ed11"}, {"alg": "SHA-1", "content": "fdd0b6aa3c9c7a188c3bfbf6dfd8d40e843be9ef"}, {"alg": "SHA-256", "content": "2de906598bfb44d3e6833c36e1ad9c565275af16da25e13e6f676126f613908c"}, {"alg": "SHA-512", "content": "24ba927d8ea0ca58a8a6722fe99ed165b7174926a3f2ac731eaa8383e7f6b9f74caf7ae39562ef9ee324914ccf8ad5b6b7270bfc688a461c6feed089e778dffb"}, {"alg": "SHA-384", "content": "67209dd624bfaa95f376772e89f0e574b971d9224a2c5ca91645a9a00b3e25ab8c4594e96ac7de09c2ac111767ec39ad"}, {"alg": "SHA3-384", "content": "e5a7367855624bc08bbf442cece3b894a285068b7a328e3451818fda2d9a148678c736a18d98eef1a6490587329015f2"}, {"alg": "SHA3-256", "content": "3f0c5849b9b772b3544611b78300843d6751fac5bf80dbec44a07d0fb95bb75c"}, {"alg": "SHA3-512", "content": "e3871a6dea5b1a64cc8fba9b05a48a83b3924190f9eab5d576583ec9060cbf1982133f845360f0aa2f05cd9dab6b00a6e5f5dff5d8a33914848fff9bfe0f63d4"}], "licenses": [{"license": {"id": "Apache-2.0"}}], "name": "spring-aop", "publisher": "Spring IO", "purl": "pkg:maven/org.springframework/spring-aop@5.0.7.RELEASE?type=jar", "scope": "required", "type": "framework", "version": "5.0.7.RELEASE"}, {"bom-ref": "pkg:maven/org.springframework/spring-beans@5.0.7.RELEASE?type=jar", "description": "Spring Beans", "evidence": {"identity": {"confidence": 0.8, "field": "purl", "methods": [{"confidence": 0.8, "technique": "binary-analysis", "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\org\\springframework\\spring-beans\\5.0.7.RELEASE\\spring-beans-5.0.7.RELEASE.jar"}]}, "occurrences": [{"location": "account-service\\src\\main\\java\\com\\piggymetrics\\account\\config\\ResourceServerConfig.java#28"}]}, "group": "org.springframework", "hashes": [{"alg": "MD5", "content": "c850badbb984cda6983da22c8672a59f"}, {"alg": "SHA-1", "content": "c1196cb3e56da83e3c3a02ef323699f4b05feedc"}, {"alg": "SHA-256", "content": "0d0adc1832406304985a72d2c79c6d0af481f34ae2a9c4a3835c9b0968da25e3"}, {"alg": "SHA-512", "content": "58b8e141981594d43cc52fd179f512a1919eaa4ddd323127302fd753b5befb1b5ee8fc3b70adf4963bdaa181ac3ff67ed643bdacdde2881c26f12f55d3c34190"}, {"alg": "SHA-384", "content": "d2aaea6cd85065710cdc27d25dfd7bdfdea57f0f796214767e83f09b967c6cb2c954369a40e2e6f55f4106b43d099558"}, {"alg": "SHA3-384", "content": "f35b746798ceaad156b257f6c208cc3e9783244d68501187af355a98613c048b62cee350b728c67fc067ddca41fabbe1"}, {"alg": "SHA3-256", "content": "72ae91c81771a542fb4ce30b45608b43dcfe03d9e18070763e7421fa0389d52c"}, {"alg": "SHA3-512", "content": "ecb8c1471d73b885db4b4796a95a1af1e229f33724f2d3cbdf8df947f84fd1dcc6064a8ef2552189304df475283c9c899d4bcb3bdf3a0f97390aed50d0f8815b"}], "licenses": [{"license": {"id": "Apache-2.0"}}], "name": "spring-beans", "publisher": "Spring IO", "purl": "pkg:maven/org.springframework/spring-beans@5.0.7.RELEASE?type=jar", "scope": "required", "type": "framework", "version": "5.0.7.RELEASE"}, {"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.0.3.RELEASE?type=jar", "description": "Spring Boot AutoConfigure", "evidence": {"callstack": {"frames": [{"fullFilename": "statistics-service\\src\\main\\java\\com\\piggymetrics\\statistics\\config\\ResourceServerConfig.java", "function": "tokenServices", "line": 21, "module": "com.piggymetrics.statistics.config.ResourceServerConfig", "package": "com.piggymetrics.statistics.config"}, {"column": 48, "fullFilename": "statistics-service\\src\\main\\java\\com\\piggymetrics\\statistics\\config\\ResourceServerConfig.java", "function": "tokenServices", "line": 23, "module": "com.piggymetrics.statistics.config.ResourceServerConfig", "package": "com.piggymetrics.statistics.config"}, {"column": 70, "fullFilename": "statistics-service\\src\\main\\java\\com\\piggymetrics\\statistics\\config\\ResourceServerConfig.java", "function": "tokenServices", "line": 23, "module": "com.piggymetrics.statistics.config.ResourceServerConfig", "package": "com.piggymetrics.statistics.config"}, {"column": 70, "fullFilename": "statistics-service\\src\\main\\java\\com\\piggymetrics\\statistics\\config\\ResourceServerConfig.java", "function": "tokenServices", "line": 23, "module": "com.piggymetrics.statistics.config.ResourceServerConfig", "package": "com.piggymetrics.statistics.config"}, {"column": 65, "fullFilename": "statistics-service\\src\\main\\java\\com\\piggymetrics\\statistics\\service\\security\\CustomUserInfoTokenServices.java", "function": "<init>", "line": 46, "module": "com.piggymetrics.statistics.service.security.CustomUserInfoTokenServices", "package": "com.piggymetrics.statistics.service.security"}, {"column": 19, "fullFilename": "statistics-service\\src\\main\\java\\com\\piggymetrics\\statistics\\service\\security\\CustomUserInfoTokenServices.java", "function": "<init>", "line": 48, "module": "com.piggymetrics.statistics.service.security.CustomUserInfoTokenServices", "package": "com.piggymetrics.statistics.service.security"}, {"column": 3, "fullFilename": "statistics-service\\src\\main\\java\\com\\piggymetrics\\statistics\\service\\security\\CustomUserInfoTokenServices.java", "function": "<init>", "line": 48, "module": "com.piggymetrics.statistics.service.security.CustomUserInfoTokenServices", "package": "com.piggymetrics.statistics.service.security"}, {"fullFilename": "statistics-service\\src\\main\\java\\com\\piggymetrics\\statistics\\service\\security\\CustomUserInfoTokenServices.java", "function": "<init>", "line": 46, "module": "", "package": ""}, {"fullFilename": "statistics-service\\src\\main\\java\\com\\piggymetrics\\statistics\\config\\ResourceServerConfig.java", "function": "tokenServices", "module": "com.piggymetrics.statistics.config.ResourceServerConfig", "package": "com.piggymetrics.statistics.config"}, {"column": 9, "fullFilename": "statistics-service\\src\\main\\java\\com\\piggymetrics\\statistics\\config\\ResourceServerConfig.java", "function": "tokenServices", "line": 23, "module": "com.piggymetrics.statistics.config.ResourceServerConfig", "package": "com.piggymetrics.statistics.config"}]}, "identity": {"confidence": 0.8, "field": "purl", "methods": [{"confidence": 0.8, "technique": "binary-analysis", "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\org\\springframework\\boot\\spring-boot-autoconfigure\\2.0.3.RELEASE\\spring-boot-autoconfigure-2.0.3.RELEASE.jar"}]}, "occurrences": [{"location": "account-service\\src\\main\\java\\com\\piggymetrics\\account\\AccountApplication.java#11"}, {"location": "auth-service\\src\\main\\java\\com\\piggymetrics\\auth\\AuthApplication.java#9"}, {"location": "config\\src\\main\\java\\com\\piggymetrics\\config\\ConfigApplication.java#7"}, {"location": "gateway\\src\\main\\java\\com\\piggymetrics\\gateway\\GatewayApplication.java#8"}, {"location": "monitoring\\src\\main\\java\\com\\piggymetrics\\monitoring\\MonitoringApplication.java#7"}, {"location": "notification-service\\src\\main\\java\\com\\piggymetrics\\notification\\NotificationServiceApplication.java#18"}, {"location": "registry\\src\\main\\java\\com\\piggymetrics\\registry\\RegistryApplication.java#7"}, {"location": "statistics-service\\src\\main\\java\\com\\piggymetrics\\statistics\\StatisticsApplication.java#21"}, {"location": "turbine-stream-service\\src\\main\\java\\com\\piggymetrics\\turbine\\TurbineStreamServiceApplication.java#8"}]}, "group": "org.springframework.boot", "hashes": [{"alg": "MD5", "content": "0a52980d8c71d372ee9c6b100da7f49b"}, {"alg": "SHA-1", "content": "011bc4cc96b08fabad2b3186755818fa0b32d83f"}, {"alg": "SHA-256", "content": "742df8010f51ac98a14ff19fbd6df1ef0aca7656ad475295fa90444389d2d9d4"}, {"alg": "SHA-512", "content": "c2918394ff63ad616f64fd2900cc1c688f8772cf05a3f206d2521e2ab525bda29f6e87b18ca7ae4c4c6cd4a248032d51cc0a0d4806370166efbabc77173caac2"}, {"alg": "SHA-384", "content": "cad79a4a727581de121cc68864c456863f396e85adc7b1514bae5f874b5a50ce134ce7723c1697e297d4c61b29dcbd5c"}, {"alg": "SHA3-384", "content": "5bfb3d163cfaaa467d760860d0c0e3825c1bccf2b62626822eb0eaa272bec13798b09b4137b109c58836c3d7566af73d"}, {"alg": "SHA3-256", "content": "7d51c2f934ca270814c03cb35422d183a5fd16cce3b7a707047f7e1ae610b099"}, {"alg": "SHA3-512", "content": "e057673f1fe4b86b0b3bd60d2feeef09549bd373cfd56e8d8a88b13272f8824b87bc8cfd02fb9739b1456ffa82567e1e99ca3cf6d5c1b7954cd0a0aa8f4d4299"}], "licenses": [{"license": {"id": "Apache-2.0"}}], "name": "spring-boot-autoconfigure", "publisher": "Pivotal Software, Inc.", "purl": "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.0.3.RELEASE?type=jar", "scope": "required", "type": "framework", "version": "2.0.3.RELEASE"}, {"bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-aop@2.0.3.RELEASE?type=jar", "description": "Starter for aspect-oriented programming with Spring AOP and AspectJ", "evidence": {"identity": {"confidence": 0.8, "field": "purl", "methods": [{"confidence": 0.8, "technique": "binary-analysis", "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\org\\springframework\\boot\\spring-boot-starter-aop\\2.0.3.RELEASE\\spring-boot-starter-aop-2.0.3.RELEASE.jar"}]}}, "group": "org.springframework.boot", "hashes": [{"alg": "MD5", "content": "0c857777c2044cd2ececee6b70c1cef5"}, {"alg": "SHA-1", "content": "a78c7bc25fd51b217f078421dc40d13ddc3b9f8f"}, {"alg": "SHA-256", "content": "ddfc437ff26e206e74d8d2b949a978dc39a5bfdade596ab280a9d56efff2d5b1"}, {"alg": "SHA-512", "content": "329768326aa539dbdfda2d7eb79798deccc00948c05a6029159e25058832374789465df103da18fc88a949a08d0c439dde93b7383237106b7b92aac742f2a674"}, {"alg": "SHA-384", "content": "c6cd2c55f39efda38caf74099d2340b02d853c47cf688d66ca8fbcdbd674b1a9725d5553899f2c0ab5c65f5f11c41f10"}, {"alg": "SHA3-384", "content": "040f344c92763062c6fa2a6de1de4b07d4156db2e6a1b10189af28887a5dcd70a6b8eb505f953910310baaf42c9a06c1"}, {"alg": "SHA3-256", "content": "0b2ef68be5c3f07c5a385ca24cbf50cacffe25f38eb440df5bb2ea9e79d10ff3"}, {"alg": "SHA3-512", "content": "ef3aecc2f2545c8224dff5e7dec998b3a2d94c6bb6296b08cf732f8488336431cd152cc15007ddb062cff00e465d9b288205dcbace1bab3859f069748d597674"}], "licenses": [{"license": {"id": "Apache-2.0"}}], "name": "spring-boot-starter-aop", "publisher": "Pivotal Software, Inc.", "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-aop@2.0.3.RELEASE?type=jar", "scope": "required", "type": "framework", "version": "2.0.3.RELEASE"}, {"bom-ref": "pkg:maven/org.springframework.cloud/spring-cloud-config-client@2.0.0.RELEASE?type=jar", "description": "This project is a Spring configuration client.", "evidence": {"identity": {"confidence": 0.8, "field": "purl", "methods": [{"confidence": 0.8, "technique": "binary-analysis", "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\org\\springframework\\cloud\\spring-cloud-config-client\\2.0.0.RELEASE\\spring-cloud-config-client-2.0.0.RELEASE.jar"}]}}, "group": "org.springframework.cloud", "hashes": [{"alg": "MD5", "content": "5f479b27ddaa0d47f0cc6e150ac05c33"}, {"alg": "SHA-1", "content": "7a3f4447664c61ff674c29a9b2ff0dc988dee316"}, {"alg": "SHA-256", "content": "a4c26aaa864418c008b3fb067ad3b54da9a968921db4bab47366b97bd8f8ca30"}, {"alg": "SHA-512", "content": "b545b2744f31d5cc8fd7cf89e42bf7dc1a4464d1761d28f48f7446906c6bd43ec2a696eac0ba2708723ebee36b1f6316f37972e24b76eb1a621f0f153779d4ea"}, {"alg": "SHA-384", "content": "15b9e5813ca5260a888248932b83b3e63cd27bf46ac5db0091718c7c6e91e5d78d7889da0b1fdbaaa12de74e0fdedc49"}, {"alg": "SHA3-384", "content": "48ae1e40ca060c109ce89ae48eba68bb348f05aaab6f074aec8c969b66e7b3a811e8bc6e8901c183c14085612bb01dfa"}, {"alg": "SHA3-256", "content": "263ebd750a961f58776b4cf085feb28381530eace5b8c75d9011eeb19a2bb98d"}, {"alg": "SHA3-512", "content": "3d3fd94e8f281be0c4d8059dfd199ac117afba71bbd777c412f7ec7c2937a2e0caa9f01197948f9df1ebb854e0082c7dc3881bf0b7f599607444c3d4bd3016dd"}], "licenses": [{"license": {"id": "Apache-2.0"}}], "name": "spring-cloud-config-client", "publisher": "Pivotal Software, Inc.", "purl": "pkg:maven/org.springframework.cloud/spring-cloud-config-client@2.0.0.RELEASE?type=jar", "scope": "required", "type": "framework", "version": "2.0.0.RELEASE"}, {"bom-ref": "pkg:maven/org.springframework.cloud/spring-cloud-netflix-core@2.0.0.RELEASE?type=jar", "description": "Spring Cloud Netflix Core", "evidence": {"identity": {"confidence": 0.8, "field": "purl", "methods": [{"confidence": 0.8, "technique": "binary-analysis", "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\org\\springframework\\cloud\\spring-cloud-netflix-core\\2.0.0.RELEASE\\spring-cloud-netflix-core-2.0.0.RELEASE.jar"}]}}, "group": "org.springframework.cloud", "hashes": [{"alg": "MD5", "content": "2070a3bc6e5b770d52cdd65858ddda07"}, {"alg": "SHA-1", "content": "796bf4e966fac782c2118396d5504e01d5bd3115"}, {"alg": "SHA-256", "content": "8651ad06e6c91fadd5bf77fba528b9a23a66fb3b57b495ea8da20def6f3b5f6e"}, {"alg": "SHA-512", "content": "7814ad392c384ba4186f164e8b663e600a90c577de54ac89b967126cfe462ce08a2f295f7e54f94db3902f49de8838c70faec413d78a2d23a339a609cadcd41c"}, {"alg": "SHA-384", "content": "accd2bb47510f90c7df339cca211b5bf66321df9fdd5a157ed23adc012cd1f914cd94c4174cacb3e641b748ea4275e25"}, {"alg": "SHA3-384", "content": "77e17180e15dca51e4f3d69ff91cc90467f772d014c7a826595b5e1892a0f57bc4b4e037a59495558fefa71764fd5993"}, {"alg": "SHA3-256", "content": "cb9798a3a5fdf0b1c3233f60f16e9f9ee74e4d451318fb905221ee652828dfff"}, {"alg": "SHA3-512", "content": "e3f2ef307447c7e5cb994da1ca5c3ca390971a7d6062dbdf11f53cf28fe65eb5e1df31ec38474ab4e0feb2dddbc4b519a4984e5509212b5d79906eaaebed3f78"}], "licenses": [{"license": {"id": "Apache-2.0"}}], "name": "spring-cloud-netflix-core", "publisher": "Pivotal Software, Inc.", "purl": "pkg:maven/org.springframework.cloud/spring-cloud-netflix-core@2.0.0.RELEASE?type=jar", "scope": "required", "type": "framework", "version": "2.0.0.RELEASE"}, {"bom-ref": "pkg:maven/org.springframework.cloud/spring-cloud-netflix-eureka-client@2.0.0.RELEASE?type=jar", "description": "Spring Cloud Netflix Eureka Client", "evidence": {"identity": {"confidence": 0.8, "field": "purl", "methods": [{"confidence": 0.8, "technique": "binary-analysis", "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\org\\springframework\\cloud\\spring-cloud-netflix-eureka-client\\2.0.0.RELEASE\\spring-cloud-netflix-eureka-client-2.0.0.RELEASE.jar"}]}}, "group": "org.springframework.cloud", "hashes": [{"alg": "MD5", "content": "8b93d4d30de32748b186aeacfa618f67"}, {"alg": "SHA-1", "content": "e00b09813d5d3714dbbc150b91553267124e2250"}, {"alg": "SHA-256", "content": "7ff7145adc938be815a8055af0cdea0f720c6b356b57ac2136e53bcd5d25e97f"}, {"alg": "SHA-512", "content": "8a3f0018f3bdc5bb1ad4e246526cbdb422202d2b699c3a0cac0a765dd1d865f87b778a702f96ff2ad7b8ac6197afa46b6a6555c694ad57e0d3ce8608d071da73"}, {"alg": "SHA-384", "content": "dd690fb96277a00f46f6f81f53204d831853065abfc1bd57e61872b2c4c6858d26cd4be36d88cda8bd05e6e162c14299"}, {"alg": "SHA3-384", "content": "237201a38459c81ecedba61d4d59a522cbea01b65297c1f068e11294dbc9da626035815b1846f08c1737058e33f021e9"}, {"alg": "SHA3-256", "content": "cad94fdc93582973a4376fd3c4ee59ee34855af8f125db916de6e9b1a4b47793"}, {"alg": "SHA3-512", "content": "fcca16621c429111e17349f412e5f630df3aaed591e8c67457902512f293dbd890c40bd481660e1f95ab4ee3674450e37bf1291afad0e7d8f540c61c267217b4"}], "licenses": [{"license": {"id": "Apache-2.0"}}], "name": "spring-cloud-netflix-eureka-client", "publisher": "Pivotal Software, Inc.", "purl": "pkg:maven/org.springframework.cloud/spring-cloud-netflix-eureka-client@2.0.0.RELEASE?type=jar", "scope": "required", "type": "framework", "version": "2.0.0.RELEASE"}, {"bom-ref": "pkg:maven/org.springframework.cloud/spring-cloud-starter-netflix-eureka-client@2.0.0.RELEASE?type=jar", "description": "Spring Cloud Starter Netflix Eureka Client", "evidence": {"identity": {"confidence": 0.8, "field": "purl", "methods": [{"confidence": 0.8, "technique": "binary-analysis", "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\org\\springframework\\cloud\\spring-cloud-starter-netflix-eureka-client\\2.0.0.RELEASE\\spring-cloud-starter-netflix-eureka-client-2.0.0.RELEASE.jar"}]}}, "group": "org.springframework.cloud", "hashes": [{"alg": "MD5", "content": "46d482bf052f34fc1fde298864af2215"}, {"alg": "SHA-1", "content": "4e241e6685a4dfc45987945df6c2477503ae20d7"}, {"alg": "SHA-256", "content": "4686ea441f3b924e7f1631d49a6fb89a771a778fc7fd32612163d3c60ec21d14"}, {"alg": "SHA-512", "content": "2e512df35dff02c0814d1a59a7ba7dbf8a4280c1658565c115f5a599f80401df9d5da043b3c0868230b79ba7c04ec53138f98aeede29fd703ae2ea25d7f357b4"}, {"alg": "SHA-384", "content": "fe253756cdd8724e26477c505988966012a1e103b07e2f404967ed6760f0cb934d288c5aef8883f462e19a2fe9ea9841"}, {"alg": "SHA3-384", "content": "3a5cd5b3839f0fc79088457664f01597a6f948aa76efda13886f9144fa826b801ecf9b4d2b8135dd2d7d139fb985cacc"}, {"alg": "SHA3-256", "content": "2d792b6b575950436fe620ac173535a7fa0b7deccf290cbeb37ae7a21b6f6416"}, {"alg": "SHA3-512", "content": "3aa2f65011ba5f3923f0925d1b85180528ab5c57293353b3022ed8e3f90798a77cf13eae4beaea7d54eb60049a4776f5d9c994d56727c8bd7f8e4b9b39aa9d98"}], "licenses": [{"license": {"id": "Apache-2.0"}}], "name": "spring-cloud-starter-netflix-eureka-client", "publisher": "Pivotal Software, Inc.", "purl": "pkg:maven/org.springframework.cloud/spring-cloud-starter-netflix-eureka-client@2.0.0.RELEASE?type=jar", "scope": "required", "type": "framework", "version": "2.0.0.RELEASE"}, {"bom-ref": "pkg:maven/org.springframework/spring-web@5.0.7.RELEASE?type=jar", "description": "Spring Web", "evidence": {"identity": {"confidence": 0.8, "field": "purl", "methods": [{"confidence": 0.8, "technique": "binary-analysis", "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\org\\springframework\\spring-web\\5.0.7.RELEASE\\spring-web-5.0.7.RELEASE.jar"}]}, "occurrences": [{"location": "account-service\\src\\main\\java\\com\\piggymetrics\\account\\client\\AuthServiceClient.java#12"}, {"location": "account-service\\src\\main\\java\\com\\piggymetrics\\account\\client\\StatisticsServiceClient.java#13"}, {"location": "account-service\\src\\main\\java\\com\\piggymetrics\\account\\controller\\AccountController.java#13"}, {"location": "account-service\\src\\main\\java\\com\\piggymetrics\\account\\controller\\AccountController.java#20"}, {"location": "account-service\\src\\main\\java\\com\\piggymetrics\\account\\controller\\AccountController.java#25"}, {"location": "account-service\\src\\main\\java\\com\\piggymetrics\\account\\controller\\AccountController.java#30"}, {"location": "account-service\\src\\main\\java\\com\\piggymetrics\\account\\controller\\AccountController.java#35"}, {"location": "account-service\\src\\main\\java\\com\\piggymetrics\\account\\controller\\ErrorHandler.java#10"}, {"location": "account-service\\src\\main\\java\\com\\piggymetrics\\account\\controller\\ErrorHandler.java#17"}, {"location": "account-service\\src\\main\\java\\com\\piggymetrics\\account\\controller\\ErrorHandler.java#18"}, {"location": "account-service\\src\\main\\java\\com\\piggymetrics\\account\\service\\security\\CustomUserInfoTokenServices.java#129"}, {"location": "auth-service\\src\\main\\java\\com\\piggymetrics\\auth\\controller\\UserController.java#15"}, {"location": "auth-service\\src\\main\\java\\com\\piggymetrics\\auth\\controller\\UserController.java#16"}, {"location": "auth-service\\src\\main\\java\\com\\piggymetrics\\auth\\controller\\UserController.java#22"}, {"location": "auth-service\\src\\main\\java\\com\\piggymetrics\\auth\\controller\\UserController.java#28"}, {"location": "notification-service\\src\\main\\java\\com\\piggymetrics\\notification\\client\\AccountServiceClient.java#12"}, {"location": "notification-service\\src\\main\\java\\com\\piggymetrics\\notification\\controller\\RecipientController.java#14"}, {"location": "notification-service\\src\\main\\java\\com\\piggymetrics\\notification\\controller\\RecipientController.java#15"}, {"location": "notification-service\\src\\main\\java\\com\\piggymetrics\\notification\\controller\\RecipientController.java#21"}, {"location": "notification-service\\src\\main\\java\\com\\piggymetrics\\notification\\controller\\RecipientController.java#26"}, {"location": "statistics-service\\src\\main\\java\\com\\piggymetrics\\statistics\\client\\ExchangeRatesClient.java#13"}, {"location": "statistics-service\\src\\main\\java\\com\\piggymetrics\\statistics\\controller\\StatisticsController.java#14"}, {"location": "statistics-service\\src\\main\\java\\com\\piggymetrics\\statistics\\controller\\StatisticsController.java#20"}, {"location": "statistics-service\\src\\main\\java\\com\\piggymetrics\\statistics\\controller\\StatisticsController.java#26"}, {"location": "statistics-service\\src\\main\\java\\com\\piggymetrics\\statistics\\controller\\StatisticsController.java#32"}]}, "group": "org.springframework", "hashes": [{"alg": "MD5", "content": "cdb97ca6e419ea429244db6b01ea9d09"}, {"alg": "SHA-1", "content": "2e04c6c2922fbfa06b5948be14a5782db168b6ec"}, {"alg": "SHA-256", "content": "d100479905e911a3201de66566f59bd5e2d4137f9d95b6d314acbb80ae985d22"}, {"alg": "SHA-512", "content": "da438577b4aeb0722ecfcaccfc43a37a07c78fdd6badc87caceb3abe58f31f82df9199e26a6b889a24bfe30cdf47626fbe8c4eb68e0f49497bd4b34e99f88b66"}, {"alg": "SHA-384", "content": "8af38fbf471db8437161cca583b115bad2084544661de14b98f023013eac4a735e7f820bdaf72118e55b5cbaf78cf1da"}, {"alg": "SHA3-384", "content": "797a7bd86ef730de5377d6fc66c1b7d03188260b62fbb72a58fbc025926877bbc94b5a7c7a03e4f4e1c0b12fe9a3df13"}, {"alg": "SHA3-256", "content": "f86905c962d81e77ccdfeb4e189aad1cd22d015f7b35cb676a940e39aeb7c284"}, {"alg": "SHA3-512", "content": "e15fe01672fed6048e69d14ff865ce2986343d339c4ed806e5de0a2038b01a25dbbf457d3aa399692e8d8ad834c03e84619f683cd5bfee03facbf4500fbc51bb"}], "licenses": [{"license": {"id": "Apache-2.0"}}], "name": "spring-web", "publisher": "Spring IO", "purl": "pkg:maven/org.springframework/spring-web@5.0.7.RELEASE?type=jar", "scope": "required", "type": "framework", "version": "5.0.7.RELEASE"}], "applications": [], "other_types": []}, "misc_data": {}, "services": [{"authenticated": true, "endpoints": ["/{name}"], "name": "com-piggymetrics-account-controller-AccountController-getAccountByName-service", "x-trust-boundary": true}, {"endpoints": ["/current"], "name": "com-piggymetrics-account-controller-AccountController-getCurrentAccount-service"}, {"endpoints": ["/current"], "name": "com-piggymetrics-account-controller-AccountController-saveCurrentAccount-service"}, {"endpoints": ["/current"], "name": "com-piggymetrics-auth-controller-UserController-getUser-service"}, {"endpoints": ["/accounts/{accountName}"], "name": "com-piggymetrics-notification-client-AccountServiceClient-getAccount-service"}, {"endpoints": ["/current"], "name": "com-piggymetrics-notification-controller-RecipientController-getCurrentNotificationsSettings-service"}, {"endpoints": ["/current"], "name": "com-piggymetrics-notification-controller-RecipientController-saveCurrentNotificationsSettings-service"}, {"endpoints": ["/latest"], "name": "com-piggymetrics-statistics-client-ExchangeRatesClient-getRates-service"}], "dependencies": [{"ref": "pkg:maven/ch.qos.logback/logback-classic@1.2.3?type=jar", "dependsOn": ["pkg:maven/ch.qos.logback/logback-core@1.2.3?type=jar", "pkg:maven/org.slf4j/slf4j-api@1.7.25?type=jar"]}, {"ref": "pkg:maven/ch.qos.logback/logback-core@1.2.3?type=jar", "dependsOn": []}, {"ref": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.10.0?type=jar", "dependsOn": ["pkg:maven/org.apache.logging.log4j/log4j-api@2.10.0?type=jar", "pkg:maven/org.slf4j/slf4j-api@1.7.25?type=jar"]}, {"ref": "pkg:maven/org.slf4j/slf4j-api@1.7.25?type=jar", "dependsOn": []}, {"ref": "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.0.3.RELEASE?type=jar", "dependsOn": ["pkg:maven/org.springframework.boot/spring-boot@2.0.3.RELEASE?type=jar"]}, {"ref": "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.0.3.RELEASE?type=jar", "dependsOn": ["pkg:maven/ch.qos.logback/logback-classic@1.2.3?type=jar", "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.10.0?type=jar", "pkg:maven/org.slf4j/jul-to-slf4j@1.7.25?type=jar"]}, {"ref": "pkg:maven/org.springframework.boot/spring-boot@2.0.3.RELEASE?type=jar", "dependsOn": ["pkg:maven/org.springframework/spring-context@5.0.7.RELEASE?type=jar", "pkg:maven/org.springframework/spring-core@5.0.7.RELEASE?type=jar"]}, {"ref": "pkg:maven/org.springframework/spring-aop@5.0.7.RELEASE?type=jar", "dependsOn": ["pkg:maven/org.springframework/spring-beans@5.0.7.RELEASE?type=jar", "pkg:maven/org.springframework/spring-core@5.0.7.RELEASE?type=jar"]}, {"ref": "pkg:maven/org.springframework/spring-beans@5.0.7.RELEASE?type=jar", "dependsOn": ["pkg:maven/org.springframework/spring-core@5.0.7.RELEASE?type=jar"]}, {"ref": "pkg:maven/org.springframework/spring-context@5.0.7.RELEASE?type=jar", "dependsOn": ["pkg:maven/org.springframework/spring-aop@5.0.7.RELEASE?type=jar", "pkg:maven/org.springframework/spring-beans@5.0.7.RELEASE?type=jar", "pkg:maven/org.springframework/spring-core@5.0.7.RELEASE?type=jar", "pkg:maven/org.springframework/spring-expression@5.0.7.RELEASE?type=jar"]}, {"ref": "pkg:maven/org.springframework/spring-core@5.0.7.RELEASE?type=jar", "dependsOn": ["pkg:maven/org.springframework/spring-jcl@5.0.7.RELEASE?type=jar"]}, {"ref": "pkg:maven/org.springframework/spring-expression@5.0.7.RELEASE?type=jar", "dependsOn": ["pkg:maven/org.springframework/spring-core@5.0.7.RELEASE?type=jar"]}, {"ref": "pkg:maven/org.springframework/spring-jcl@5.0.7.RELEASE?type=jar", "dependsOn": []}]}}}, "result_5": {"common_summary": {"components": {"libraries": [{"bom-ref": "pkg:pypi/jinja2@2.11.3", "evidence": {"identity": {"confidence": 0.8, "field": "purl", "methods": [{"confidence": 0.8, "technique": "manifest-analysis", "value": "C:\\Users\\user\\PycharmProjects\\flask-webgoat\\requirements.txt"}]}}, "group": "", "name": "Jinja2", "properties": [{"name": "SrcFile", "value": "C:\\Users\\user\\PycharmProjects\\flask-webgoat\\requirements.txt"}], "purl": "pkg:pypi/jinja2@2.11.3", "type": "library", "version": "2.10.2"}], "frameworks": [{"bom-ref": "pkg:pypi/flask@1.1.2", "evidence": {"identity": {"confidence": 1, "field": "purl", "methods": [{"confidence": 1, "technique": "instrumentation", "value": "C:\\Users\\user\\PycharmProjects\\flask-webgoat\\venv"}]}, "occurrences": [{"location": "flask_webgoat\\__init__.py#20"}, {"location": "flask_webgoat\\actions.py#13"}, {"location": "flask_webgoat\\actions.py#16"}, {"location": "flask_webgoat\\actions.py#19"}, {"location": "flask_webgoat\\actions.py#22"}, {"location": "flask_webgoat\\actions.py#34"}, {"location": "flask_webgoat\\actions.py#4"}, {"location": "flask_webgoat\\actions.py#46"}, {"location": "flask_webgoat\\actions.py#49"}, {"location": "flask_webgoat\\actions.py#6"}, {"location": "flask_webgoat\\actions.py#7"}, {"location": "flask_webgoat\\auth.py#13"}, {"location": "flask_webgoat\\auth.py#23"}, {"location": "flask_webgoat\\auth.py#25"}, {"location": "flask_webgoat\\auth.py#35"}, {"location": "flask_webgoat\\auth.py#4"}, {"location": "flask_webgoat\\auth.py#44"}, {"location": "flask_webgoat\\auth.py#46"}, {"location": "flask_webgoat\\status.py#13"}, {"location": "flask_webgoat\\status.py#3"}, {"location": "flask_webgoat\\status.py#8"}, {"location": "flask_webgoat\\ui.py#14"}, {"location": "flask_webgoat\\ui.py#19"}, {"location": "flask_webgoat\\ui.py#24"}, {"location": "flask_webgoat\\ui.py#6"}, {"location": "flask_webgoat\\users.py#14"}, {"location": "flask_webgoat\\users.py#18"}, {"location": "flask_webgoat\\users.py#24"}, {"location": "flask_webgoat\\users.py#3"}, {"location": "flask_webgoat\\users.py#33"}, {"location": "flask_webgoat\\users.py#44"}, {"location": "flask_webgoat\\users.py#46"}, {"location": "flask_webgoat\\users.py#7"}]}, "group": "", "name": "flask", "properties": [{"name": "ImportedModules", "value": "flask.redirect,flask.render_template,flask.jsonify,flask.Blueprint,flask.session,flask.g,flask.request,flask.Flask"}], "purl": "pkg:pypi/flask@1.1.2", "type": "framework", "version": "1.1.2"}], "applications": [{"bom-ref": "pkg:github/actions/checkout@v2", "group": "actions", "name": "checkout", "purl": "pkg:github/actions/checkout@v2", "type": "application", "version": "v2"}, {"bom-ref": "pkg:github/actions/setup-python@v2", "group": "actions", "name": "setup-python", "purl": "pkg:github/actions/setup-python@v2", "type": "application", "version": "v2"}], "other_types": []}, "misc_data": {"bomFormat": "CycloneDX", "metadata": {"authors": [{"name": "OWASP Foundation"}], "component": {"bom-ref": "pkg:gem/flask-webgoat@latest", "group": "", "name": "flask-webgoat", "purl": "pkg:gem/flask-webgoat@latest", "type": "application", "version": "latest"}, "lifecycles": [{"phase": "build"}], "tools": {"components": [{"author": "OWASP Foundation", "group": "@cyclonedx", "name": "cdxgen", "publisher": "OWASP Foundation", "type": "application"}]}}, "specVersion": "1.5", "version": 2}, "services": [{"authenticated": false, "endpoints": ["/message", "/grep_processes"], "name": "actions-service"}, {"authenticated": false, "endpoints": ["/login", "/login_and_redirect"], "name": "auth-service"}, {"authenticated": false, "endpoints": ["/status", "/ping"], "name": "status-service"}, {"authenticated": false, "endpoints": ["/search"], "name": "ui-service"}], "dependencies": [{"ref": "pkg:pypi/flask-webgoat", "dependsOn": ["pkg:pypi/flask"]}, {"ref": "pkg:pypi/jinja2", "dependsOn": ["pkg:pypi/markupsafe"]}, {"ref": "pkg:pypi/markupsafe", "dependsOn": []}, {"ref": "pkg:pypi/werkzeug", "dependsOn": []}]}, "diff_summary": {"test/sbom-python2.json": {"components": {"libraries": [{"bom-ref": "pkg:pypi/werkzeug@1.0.1", "evidence": {"identity": {"confidence": 0.8, "field": "purl", "methods": [{"confidence": 0.8, "technique": "manifest-analysis", "value": "C:\\Users\\user\\PycharmProjects\\flask-webgoat\\requirements.txt"}]}}, "group": "", "name": "Werkzeug", "properties": [{"name": "SrcFile", "value": "C:\\Users\\user\\PycharmProjects\\flask-webgoat\\requirements.txt"}], "purl": "pkg:pypi/werkzeug@1.0.1", "type": "library", "version": "1.5.1"}], "frameworks": [], "applications": [], "other_types": []}, "misc_data": {}}, "test/sbom-python.json": {"components": {"libraries": [{"bom-ref": "pkg:pypi/jinja2@2.11.3", "evidence": {"identity": {"confidence": 0.8, "field": "purl", "methods": [{"confidence": 0.8, "technique": "manifest-analysis", "value": "C:\\Users\\user\\PycharmProjects\\flask-webgoat\\requirements.txt"}]}}, "group": "", "name": "Jinja2", "properties": [{"name": "SrcFile", "value": "C:\\Users\\user\\PycharmProjects\\flask-webgoat\\requirements.txt"}], "purl": "pkg:pypi/jinja2@2.11.3", "type": "library", "version": "2.11.3"}, {"bom-ref": "pkg:pypi/markupsafe@1.1.1", "evidence": {"identity": {"confidence": 0.8, "field": "purl", "methods": [{"confidence": 0.8, "technique": "manifest-analysis", "value": "C:\\Users\\user\\PycharmProjects\\flask-webgoat\\requirements.txt"}]}}, "group": "", "name": "MarkupSafe", "properties": [{"name": "SrcFile", "value": "C:\\Users\\user\\PycharmProjects\\flask-webgoat\\requirements.txt"}], "purl": "pkg:pypi/markupsafe@1.1.1", "type": "library", "version": "1.1.1"}, {"bom-ref": "pkg:pypi/click@7.1.2", "evidence": {"identity": {"confidence": 0.8, "field": "purl", "methods": [{"confidence": 0.8, "technique": "manifest-analysis", "value": "C:\\Users\\user\\PycharmProjects\\flask-webgoat\\requirements.txt"}]}}, "group": "", "name": "click", "properties": [{"name": "SrcFile", "value": "C:\\Users\\user\\PycharmProjects\\flask-webgoat\\requirements.txt"}], "purl": "pkg:pypi/click@7.1.2", "type": "library", "version": "7.1.2"}, {"bom-ref": "pkg:pypi/itsdangerous@1.1.0", "evidence": {"identity": {"confidence": 0.8, "field": "purl", "methods": [{"confidence": 0.8, "technique": "manifest-analysis", "value": "C:\\Users\\user\\PycharmProjects\\flask-webgoat\\requirements.txt"}]}}, "group": "", "name": "itsdangerous", "properties": [{"name": "SrcFile", "value": "C:\\Users\\user\\PycharmProjects\\flask-webgoat\\requirements.txt"}], "purl": "pkg:pypi/itsdangerous@1.1.0", "type": "library", "version": "1.1.0"}], "frameworks": [], "applications": [], "other_types": []}, "misc_data": {}, "services": [{"authenticated": false, "endpoints": ["/create_user"], "name": "users-service"}], "dependencies": [{"ref": "pkg:pypi/click", "dependsOn": []}, {"ref": "pkg:pypi/flask", "dependsOn": ["pkg:pypi/click", "pkg:pypi/itsdangerous", "pkg:pypi/jinja2", "pkg:pypi/werkzeug"]}, {"ref": "pkg:pypi/itsdangerous", "dependsOn": []}]}}}, "result_6": {"test/sbom-python.json": {"components": [{"version": "2.11.3"}, {"bom-ref": "pkg:pypi/markupsafe@1.1.1", "name": "MarkupSafe", "purl": "pkg:pypi/markupsafe@1.1.1", "version": "1.1.1"}, {"version": "1.0.1"}, {"bom-ref": "pkg:pypi/click@7.1.2", "name": "click", "purl": "pkg:pypi/click@7.1.2", "version": "7.1.2"}, {"bom-ref": "pkg:pypi/itsdangerous@1.1.0", "name": "itsdangerous", "purl": "pkg:pypi/itsdangerous@1.1.0", "version": "1.1.0"}], "dependencies": [{"ref": "pkg:pypi/click@7.1.2"}, {"dependsOn": ["pkg:pypi/click@7.1.2", "pkg:pypi/itsdangerous@1.1.0", "pkg:pypi/jinja2@2.11.3", "pkg:pypi/werkzeug@1.0.1"], "ref": "pkg:pypi/flask@1.1.2"}, {"ref": "pkg:pypi/itsdangerous@1.1.0"}], "services": [{"endpoints": ["/create_user"], "name": "users-service"}]}, "test/sbom-python2.json": {"components": [{"version": "2.10.2"}, {"version": "1.5.1"}]}}, "result_7": {"bomFormat": "CycloneDX", "components": [{"bom-ref": "pkg:pypi/jinja2@2.11.3", "group": "", "name": "Jinja2", "purl": "pkg:pypi/jinja2@2.11.3", "type": "library"}, {"group": "", "type": "library"}, {"bom-ref": "pkg:pypi/werkzeug@1.0.1", "group": "", "name": "Werkzeug", "purl": "pkg:pypi/werkzeug@1.0.1", "type": "library"}, {"bom-ref": "pkg:github/actions/checkout@v2", "group": "actions", "name": "checkout", "purl": "pkg:github/actions/checkout@v2", "type": "application", "version": "v2"}, {"group": "", "type": "library"}, {"bom-ref": "pkg:pypi/flask@1.1.2", "group": "", "name": "flask", "purl": "pkg:pypi/flask@1.1.2", "type": "framework", "version": "1.1.2"}, {"group": "", "type": "library"}, {"bom-ref": "pkg:github/actions/setup-python@v2", "group": "actions", "name": "setup-python", "purl": "pkg:github/actions/setup-python@v2", "type": "application", "version": "v2"}], "dependencies": [{"dependsOn": []}, {"dependsOn": ["pkg:pypi/flask@1.1.2"], "ref": "pkg:pypi/flask-webgoat@latest"}, {"dependsOn": []}, {"dependsOn": ["pkg:pypi/markupsafe@1.1.1"], "ref": "pkg:pypi/jinja2@2.11.3"}, {"dependsOn": [], "ref": "pkg:pypi/markupsafe@1.1.1"}, {"dependsOn": [], "ref": "pkg:pypi/werkzeug@1.0.1"}], "metadata": {"authors": [{"name": "OWASP Foundation"}], "component": {"bom-ref": "pkg:gem/flask-webgoat@latest", "group": "", "name": "flask-webgoat", "purl": "pkg:gem/flask-webgoat@latest", "type": "application", "version": "latest"}, "lifecycles": [{"phase": "build"}], "tools": {"components": [{"author": "OWASP Foundation", "group": "@cyclonedx", "name": "cdxgen", "publisher": "OWASP Foundation", "type": "application"}]}}, "services": [{"authenticated": false, "endpoints": ["/message", "/grep_processes"], "name": "actions-service"}, {"authenticated": false, "endpoints": ["/login", "/login_and_redirect"], "name": "auth-service"}, {"authenticated": false, "endpoints": ["/status", "/ping"], "name": "status-service"}, {"authenticated": false, "endpoints": ["/search"], "name": "ui-service"}, {"authenticated": false}], "specVersion": "1.5", "version": 2}, "result_8": {"components": [{"version": "2.11.3"}, {"bom-ref": "pkg:pypi/markupsafe@1.1.1", "name": "MarkupSafe", "purl": "pkg:pypi/markupsafe@1.1.1", "version": "1.1.1"}, {"version": "1.0.1"}, {"bom-ref": "pkg:pypi/click@7.1.2", "name": "click", "purl": "pkg:pypi/click@7.1.2", "version": "7.1.2"}, {"bom-ref": "pkg:pypi/itsdangerous@1.1.0", "name": "itsdangerous", "purl": "pkg:pypi/itsdangerous@1.1.0", "version": "1.1.0"}], "dependencies": [{"ref": "pkg:pypi/click@7.1.2"}, {"dependsOn": ["pkg:pypi/click@7.1.2", "pkg:pypi/itsdangerous@1.1.0", "pkg:pypi/jinja2@2.11.3", "pkg:pypi/werkzeug@1.0.1"], "ref": "pkg:pypi/flask@1.1.2"}, {"ref": "pkg:pypi/itsdangerous@1.1.0"}], "services": [{"endpoints": ["/create_user"], "name": "users-service"}]}, "result_9": {"components": [{"version": "2.10.2"}, {"version": "1.5.1"}]}, "result_12": {"bomFormat": "CycloneDX", "components": [{"bom-ref": "pkg:pypi/jinja2@2.11.3", "group": "", "name": "Jinja2", "purl": "pkg:pypi/jinja2@2.11.3", "type": "library"}, {"group": "", "type": "library"}, {"bom-ref": "pkg:pypi/werkzeug@1.0.1", "group": "", "name": "Werkzeug", "purl": "pkg:pypi/werkzeug@1.0.1", "type": "library"}, {"bom-ref": "pkg:github/actions/checkout@v2", "group": "actions", "name": "checkout", "purl": "pkg:github/actions/checkout@v2", "type": "application", "version": "v2"}, {"group": "", "type": "library"}, {"bom-ref": "pkg:pypi/flask@1.1.2", "group": "", "name": "flask", "purl": "pkg:pypi/flask@1.1.2", "type": "framework", "version": "1.1.2"}, {"group": "", "type": "library"}, {"bom-ref": "pkg:github/actions/setup-python@v2", "group": "actions", "name": "setup-python", "purl": "pkg:github/actions/setup-python@v2", "type": "application", "version": "v2"}], "dependencies": [{"dependsOn": []}, {"dependsOn": ["pkg:pypi/flask@1.1.2"], "ref": "pkg:pypi/flask-webgoat@latest"}, {"dependsOn": []}, {"dependsOn": ["pkg:pypi/markupsafe@1.1.1"], "ref": "pkg:pypi/jinja2@2.11.3"}, {"dependsOn": [], "ref": "pkg:pypi/markupsafe@1.1.1"}, {"dependsOn": [], "ref": "pkg:pypi/werkzeug@1.0.1"}], "metadata": {"authors": [{"name": "OWASP Foundation"}], "component": {"bom-ref": "pkg:gem/flask-webgoat@latest", "group": "", "name": "flask-webgoat", "purl": "pkg:gem/flask-webgoat@latest", "type": "application", "version": "latest"}, "lifecycles": [{"phase": "build"}], "tools": {"components": [{"author": "OWASP Foundation", "group": "@cyclonedx", "name": "cdxgen", "publisher": "OWASP Foundation", "type": "application"}]}}, "services": [{"authenticated": false, "endpoints": ["/message", "/grep_processes"], "name": "actions-service"}, {"authenticated": false, "endpoints": ["/login", "/login_and_redirect"], "name": "auth-service"}, {"authenticated": false, "endpoints": ["/status", "/ping"], "name": "status-service"}, {"authenticated": false, "endpoints": ["/search"], "name": "ui-service"}, {"authenticated": false}], "specVersion": "1.5", "version": 2}}
+{
+  "result_1": {
+    "common_summary": {
+      "components": {
+        "libraries": [],
+        "frameworks": [
+          {
+            "bom-ref": "pkg:maven/org.springframework.cloud/spring-cloud-starter-config@2.0.0.RELEASE?type=jar",
+            "description": "Spring Cloud Starter",
+            "group": "org.springframework.cloud",
+            "name": "spring-cloud-starter-config",
+            "publisher": "Pivotal Software, Inc.",
+            "purl": "pkg:maven/org.springframework.cloud/spring-cloud-starter-config@2.0.0.RELEASE?type=jar",
+            "scope": "required",
+            "type": "framework",
+            "version": "2.0.0.RELEASE"
+          }
+        ],
+        "applications": [],
+        "other_types": []
+      },
+      "misc_data": {}
+    },
+    "diff_summary": {
+      "bom_2.json": {
+        "components": {
+          "libraries": [
+            {
+              "bom-ref": "pkg:maven/joda-time/joda-time@2.9.9?type=jar",
+              "description": "",
+              "group": "joda-time",
+              "name": "joda-time",
+              "publisher": "Joda.org",
+              "purl": "pkg:maven/joda-time/joda-time@2.9.9?type=jar",
+              "scope": "required",
+              "type": "library",
+              "version": "2.9.9"
+            }
+          ],
+          "frameworks": [],
+          "applications": [],
+          "other_types": []
+        },
+        "misc_data": {}
+      },
+      "bom_1.json": {
+        "components": {
+          "libraries": [
+            {
+              "bom-ref": "pkg:maven/joda-time/joda-time@2.9.9?type=jar",
+              "description": "Date and time library to replace JDK date handling",
+              "group": "joda-time",
+              "name": "joda-time",
+              "publisher": "Joda.org",
+              "purl": "pkg:maven/joda-time/joda-time@2.9.9?type=jar",
+              "scope": "required",
+              "type": "library",
+              "version": "2.9.9"
+            }
+          ],
+          "frameworks": [],
+          "applications": [],
+          "other_types": []
+        },
+        "misc_data": {}
+      }
+    }
+  },
+  "result_10": {
+    "bomFormat": "CycloneDX",
+    "components": [
+      {
+        "bom-ref": "pkg:pypi/jinja2@2.11.3",
+        "group": "",
+        "name": "Jinja2",
+        "purl": "pkg:pypi/jinja2@2.11.3",
+        "type": "library",
+        "version": "2.10.2"
+      },
+      {
+        "bom-ref": "pkg:pypi/markupsafe@1.1.1",
+        "group": "",
+        "name": "MarkupSafe",
+        "purl": "pkg:pypi/markupsafe@1.1.1",
+        "type": "library",
+        "version": "1.5.1"
+      },
+      {
+        "bom-ref": "pkg:pypi/werkzeug@1.0.1",
+        "group": "",
+        "name": "Werkzeug",
+        "purl": "pkg:pypi/werkzeug@1.0.1",
+        "type": "library",
+        "version": "1.0.1"
+      },
+      {
+        "bom-ref": "pkg:github/actions/checkout@v2",
+        "group": "actions",
+        "name": "checkout",
+        "purl": "pkg:github/actions/checkout@v2",
+        "type": "application",
+        "version": "v2"
+      },
+      {
+        "bom-ref": "pkg:pypi/click@7.1.2",
+        "group": "",
+        "name": "click",
+        "purl": "pkg:pypi/click@7.1.2",
+        "type": "library",
+        "version": "7.1.2"
+      },
+      {
+        "bom-ref": "pkg:pypi/flask@1.1.2",
+        "group": "",
+        "name": "flask",
+        "purl": "pkg:pypi/flask@1.1.2",
+        "type": "framework",
+        "version": "1.1.2"
+      },
+      {
+        "bom-ref": "pkg:pypi/itsdangerous@1.1.0",
+        "group": "",
+        "name": "itsdangerous",
+        "purl": "pkg:pypi/itsdangerous@1.1.0",
+        "type": "library",
+        "version": "1.1.0"
+      },
+      {
+        "bom-ref": "pkg:github/actions/setup-python@v2",
+        "group": "actions",
+        "name": "setup-python",
+        "purl": "pkg:github/actions/setup-python@v2",
+        "type": "application",
+        "version": "v2"
+      }
+    ],
+    "dependencies": [
+      {
+        "dependsOn": [],
+        "ref": "pkg:pypi/click@7.1.2"
+      },
+      {
+        "dependsOn": [
+          "pkg:pypi/flask@1.1.2"
+        ],
+        "ref": "pkg:pypi/flask-webgoat@latest"
+      },
+      {
+        "dependsOn": [
+          "pkg:pypi/click@7.1.2",
+          "pkg:pypi/itsdangerous@1.1.0",
+          "pkg:pypi/jinja2@2.11.3",
+          "pkg:pypi/werkzeug@1.0.1"
+        ],
+        "ref": "pkg:pypi/flask@1.1.2"
+      },
+      {
+        "dependsOn": [],
+        "ref": "pkg:pypi/itsdangerous@1.1.0"
+      },
+      {
+        "dependsOn": [
+          "pkg:pypi/markupsafe@1.1.1"
+        ],
+        "ref": "pkg:pypi/jinja2@2.11.3"
+      },
+      {
+        "dependsOn": [],
+        "ref": "pkg:pypi/markupsafe@1.1.1"
+      },
+      {
+        "dependsOn": [],
+        "ref": "pkg:pypi/werkzeug@1.0.1"
+      }
+    ],
+    "metadata": {
+      "authors": [
+        {
+          "name": "OWASP Foundation"
+        }
+      ],
+      "component": {
+        "bom-ref": "pkg:gem/flask-webgoat@latest",
+        "group": "",
+        "name": "flask-webgoat",
+        "purl": "pkg:gem/flask-webgoat@latest",
+        "type": "application",
+        "version": "latest"
+      },
+      "lifecycles": [
+        {
+          "phase": "build"
+        }
+      ],
+      "tools": {
+        "components": [
+          {
+            "author": "OWASP Foundation",
+            "group": "@cyclonedx",
+            "name": "cdxgen",
+            "publisher": "OWASP Foundation",
+            "type": "application"
+          }
+        ]
+      }
+    },
+    "services": [
+      {
+        "authenticated": false,
+        "endpoints": [
+          "/message",
+          "/grep_processes"
+        ],
+        "name": "actions-service"
+      },
+      {
+        "authenticated": false,
+        "endpoints": [
+          "/login",
+          "/login_and_redirect"
+        ],
+        "name": "auth-service"
+      },
+      {
+        "authenticated": false,
+        "endpoints": [
+          "/status",
+          "/ping"
+        ],
+        "name": "status-service"
+      },
+      {
+        "authenticated": false,
+        "endpoints": [
+          "/search"
+        ],
+        "name": "ui-service"
+      },
+      {
+        "authenticated": false,
+        "endpoints": [
+          "/create_user"
+        ],
+        "name": "users-service"
+      }
+    ],
+    "specVersion": "1.5",
+    "version": 2
+  },
+  "result_11": {
+    "components": [
+      {
+        "version": "2.11.3"
+      },
+      {
+        "bom-ref": "pkg:pypi/markupsafe@1.1.1",
+        "name": "MarkupSafe",
+        "purl": "pkg:pypi/markupsafe@1.1.1",
+        "version": "1.1.1"
+      },
+      {
+        "version": "1.0.1"
+      },
+      {
+        "bom-ref": "pkg:pypi/click@7.1.2",
+        "name": "click",
+        "purl": "pkg:pypi/click@7.1.2",
+        "version": "7.1.2"
+      },
+      {
+        "bom-ref": "pkg:pypi/itsdangerous@1.1.0",
+        "name": "itsdangerous",
+        "purl": "pkg:pypi/itsdangerous@1.1.0",
+        "version": "1.1.0"
+      }
+    ],
+    "dependencies": [
+      {
+        "ref": "pkg:pypi/click@7.1.2"
+      },
+      {
+        "dependsOn": [
+          "pkg:pypi/click@7.1.2",
+          "pkg:pypi/itsdangerous@1.1.0",
+          "pkg:pypi/jinja2@2.11.3",
+          "pkg:pypi/werkzeug@1.0.1"
+        ],
+        "ref": "pkg:pypi/flask@1.1.2"
+      },
+      {
+        "ref": "pkg:pypi/itsdangerous@1.1.0"
+      }
+    ],
+    "services": [
+      {
+        "endpoints": [
+          "/create_user"
+        ],
+        "name": "users-service"
+      }
+    ]
+  },
+  "result_2": {
+    "common_summary": {
+      "components": {
+        "libraries": [],
+        "frameworks": [
+          {
+            "bom-ref": "pkg:maven/org.springframework.cloud/spring-cloud-starter-config@2.3.0.RELEASE?type=jar",
+            "description": "Spring Cloud Starter",
+            "group": "org.springframework.cloud",
+            "name": "spring-cloud-starter-config",
+            "publisher": "Pivotal Software, Inc.",
+            "purl": "pkg:maven/org.springframework.cloud/spring-cloud-starter-config@2.3.0.RELEASE?type=jar",
+            "scope": "required",
+            "type": "framework",
+            "version": "2.3.0.RELEASE"
+          }
+        ],
+        "applications": [],
+        "other_types": []
+      }
+    },
+    "diff_summary": {
+      "bom_2.json": {
+        "components": {
+          "libraries": [
+            {
+              "bom-ref": "pkg:maven/joda-time/joda-time@2.8.9?type=jar",
+              "description": "Date and time library to replace JDK date handling",
+              "group": "joda-time",
+              "name": "joda-time",
+              "publisher": "Joda.org",
+              "purl": "pkg:maven/joda-time/joda-time@2.8.9?type=jar",
+              "scope": "required",
+              "type": "library",
+              "version": "2.8.9"
+            }
+          ],
+          "frameworks": [],
+          "applications": [],
+          "other_types": []
+        }
+      },
+      "bom_1.json": {
+        "components": {
+          "libraries": [
+            {
+              "bom-ref": "pkg:maven/joda-time/joda-time@2.9.9?type=jar",
+              "description": "Date and time library to replace JDK date handling",
+              "group": "joda-time",
+              "name": "joda-time",
+              "publisher": "Joda.org",
+              "purl": "pkg:maven/joda-time/joda-time@2.9.9?type=jar",
+              "scope": "required",
+              "type": "library",
+              "version": "2.9.9"
+            }
+          ],
+          "frameworks": [],
+          "applications": [],
+          "other_types": []
+        }
+      }
+    }
+  },
+  "result_3": {
+    "common_summary": {
+      "components": {
+        "libraries": [],
+        "frameworks": [],
+        "applications": [
+          {
+            "bom-ref": "pkg:github/actions/checkout@v2",
+            "group": "actions",
+            "name": "checkout",
+            "purl": "pkg:github/actions/checkout@v2",
+            "type": "application",
+            "version": "v2"
+          }
+        ],
+        "other_types": []
+      },
+      "misc_data": {}
+    },
+    "diff_summary": {
+      "bom_2.json": {
+        "components": {
+          "libraries": [
+            {
+              "bom-ref": "pkg:pypi/werkzeug@1.1.1",
+              "group": "",
+              "name": "Werkzeug",
+              "purl": "pkg:pypi/werkzeug@1.1.1",
+              "type": "library",
+              "version": "1.1.1"
+            }
+          ],
+          "frameworks": [
+            {
+              "bom-ref": "pkg:pypi/flask@1.1.0",
+              "group": "",
+              "name": "flask",
+              "purl": "pkg:pypi/flask@1.1.0",
+              "type": "framework",
+              "version": "1.1.0"
+            }
+          ],
+          "applications": [
+            {
+              "bom-ref": "pkg:github/actions/setup-python@v2",
+              "group": "",
+              "name": "setup-python",
+              "purl": "pkg:github/actions/setup-python@v2",
+              "type": "application",
+              "version": "v2"
+            }
+          ],
+          "other_types": []
+        },
+        "misc_data": {}
+      },
+      "bom_1.json": {
+        "components": {
+          "libraries": [
+            {
+              "bom-ref": "pkg:pypi/werkzeug@1.0.1",
+              "group": "",
+              "name": "Werkzeug",
+              "purl": "pkg:pypi/werkzeug@1.0.1",
+              "type": "library",
+              "version": "1.0.1"
+            }
+          ],
+          "frameworks": [
+            {
+              "bom-ref": "pkg:pypi/flask@1.1.2",
+              "group": "",
+              "name": "flask",
+              "purl": "pkg:pypi/flask@1.1.2",
+              "type": "framework",
+              "version": "1.1.2"
+            }
+          ],
+          "applications": [
+            {
+              "bom-ref": "pkg:github/actions/setup-python@v2",
+              "group": "actions",
+              "name": "setup-python",
+              "purl": "pkg:github/actions/setup-python@v2",
+              "type": "application",
+              "version": "v2"
+            }
+          ],
+          "other_types": []
+        },
+        "misc_data": {}
+      }
+    }
+  },
+  "result_4": {
+    "common_summary": {
+      "components": {
+        "libraries": [
+          {
+            "bom-ref": "pkg:maven/org.aspectj/aspectjweaver@1.8.13?type=jar",
+            "description": "The AspectJ weaver introduces advices to java classes",
+            "evidence": {
+              "identity": {
+                "confidence": 0.8,
+                "field": "purl",
+                "methods": [
+                  {
+                    "confidence": 0.8,
+                    "technique": "binary-analysis",
+                    "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\org\\aspectj\\aspectjweaver\\1.8.13\\aspectjweaver-1.8.13.jar"
+                  }
+                ]
+              }
+            },
+            "group": "org.aspectj",
+            "hashes": [
+              {
+                "alg": "MD5",
+                "content": "4a95811a5b41a038a359c05189de9829"
+              },
+              {
+                "alg": "SHA-1",
+                "content": "ad94df2a28d658a40dc27bbaff6a1ce5fbf04e9b"
+              },
+              {
+                "alg": "SHA-256",
+                "content": "965d0928b0e07dcedb67f0d0a48653d36a6cff257e3270cb28ea48fef6c30a27"
+              },
+              {
+                "alg": "SHA-512",
+                "content": "be2b21636f7e6786c9c3c50684e522520d6bc0580ce49ff8a9c0fbe422568acbb91fd70dde63a3624098ba10d4e3892f2de0ffaa05f595278d2726b44e6aa576"
+              },
+              {
+                "alg": "SHA-384",
+                "content": "a7aa2b3cbd2abc4264f69e97e70e202c24d8fa2c67376cd1c16731fecee57b518cd41c45c0288e036100c6a7c53750ec"
+              },
+              {
+                "alg": "SHA3-384",
+                "content": "71b931c9517a44ec80139384581067a8d2ebb642d9bae8ce2ad785e6479a1e380ab9d5d5720582bd7d9e2d33c7322571"
+              },
+              {
+                "alg": "SHA3-256",
+                "content": "8fc704392325ca3d4597055a9e7780b7e2ada5bf63ca1d60a9bbfbc2c6d8f1df"
+              },
+              {
+                "alg": "SHA3-512",
+                "content": "e5d1354f72fcaf1018ff248554491077e8037c116ee6f66d98f49f290f17417bb0d73f18775f00717978755ea44533c95d13011217531d065ac3f15b9c582d7a"
+              }
+            ],
+            "licenses": [
+              {
+                "license": {
+                  "id": "EPL-1.0"
+                }
+              }
+            ],
+            "name": "aspectjweaver",
+            "purl": "pkg:maven/org.aspectj/aspectjweaver@1.8.13?type=jar",
+            "scope": "required",
+            "type": "library",
+            "version": "1.8.13"
+          },
+          {
+            "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.9.6?type=jar",
+            "description": "Core Jackson processing abstractions (aka Streaming API), implementation for JSON",
+            "evidence": {
+              "identity": {
+                "confidence": 0.8,
+                "field": "purl",
+                "methods": [
+                  {
+                    "confidence": 0.8,
+                    "technique": "binary-analysis",
+                    "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\com\\fasterxml\\jackson\\core\\jackson-core\\2.9.6\\jackson-core-2.9.6.jar"
+                  }
+                ]
+              }
+            },
+            "group": "com.fasterxml.jackson.core",
+            "hashes": [
+              {
+                "alg": "MD5",
+                "content": "f3cf83b839fac92307cad542c2ded5c4"
+              },
+              {
+                "alg": "SHA-1",
+                "content": "4e393793c37c77e042ccc7be5a914ae39251b365"
+              },
+              {
+                "alg": "SHA-256",
+                "content": "fab8746aedd6427788ee390ea04d438ec141bff7eb3476f8bdd5d9110fb2718a"
+              },
+              {
+                "alg": "SHA-512",
+                "content": "a1b9b68b67d442a47e36b46b37b6b0ad7a10c547a1cf7adb4705baec77356e1080049d310b3b530f66bbd3c0ed05cfe43c041d6ef4ffbbc6731149624df4e699"
+              },
+              {
+                "alg": "SHA-384",
+                "content": "59f87a260de53f8ddabe35749cd8abc71e52ebfeacd51b1e68363fe4bf72e632a7ea3648340969e8fdb0eb90d994fff4"
+              },
+              {
+                "alg": "SHA3-384",
+                "content": "626fc0c5049dde3d55e7b47a935e735bd0dd4aed80d22ba5ec708d581c710702a4a2f4963a1d7870692a77e05d67fd75"
+              },
+              {
+                "alg": "SHA3-256",
+                "content": "243fdbf974b456d3d96ac5c0d018c3ff2ba6f8dedeea5510da8eb851f2026efb"
+              },
+              {
+                "alg": "SHA3-512",
+                "content": "6944f9effea908ae8564a7a1a951a9c7b6e27e7cc978eac30fb43ddef0870103f669065d4b0df7293d5d541f9bf9e04b0cebbf26fdf0159d1dffb6fa465bc64f"
+              }
+            ],
+            "licenses": [
+              {
+                "license": {
+                  "id": "Apache-2.0"
+                }
+              }
+            ],
+            "name": "jackson-core",
+            "publisher": "FasterXML",
+            "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.9.6?type=jar",
+            "scope": "required",
+            "type": "library",
+            "version": "2.9.6"
+          }
+        ],
+        "frameworks": [
+          {
+            "bom-ref": "pkg:maven/org.bouncycastle/bcpkix-jdk15on@1.56?type=jar",
+            "description": "The Bouncy Castle Java APIs for CMS, PKCS, EAC, TSP, CMP, CRMF, OCSP, and certificate generation. This jar contains APIs for JDK 1.5 to JDK 1.8. The APIs can be used in conjunction with a JCE/JCA provider such as the one provided with the Bouncy Castle Cryptography APIs.",
+            "evidence": {
+              "identity": {
+                "confidence": 0.8,
+                "field": "purl",
+                "methods": [
+                  {
+                    "confidence": 0.8,
+                    "technique": "binary-analysis",
+                    "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\org\\bouncycastle\\bcpkix-jdk15on\\1.56\\bcpkix-jdk15on-1.56.jar"
+                  }
+                ]
+              }
+            },
+            "group": "org.bouncycastle",
+            "hashes": [
+              {
+                "alg": "MD5",
+                "content": "17b2b704b3ad9b36a6fca1ace60a2a06"
+              },
+              {
+                "alg": "SHA-1",
+                "content": "4648af70268b6fdb24674fb1fd7c1fcc73db1231"
+              },
+              {
+                "alg": "SHA-256",
+                "content": "7043dee4e9e7175e93e0b36f45b1ec1ecb893c5f755667e8b916eb8dd201c6ca"
+              },
+              {
+                "alg": "SHA-512",
+                "content": "6cbc73005b662440c395d81d44d0f52a3e20550f64be3d4fe413c344257c6ef31f8080421b247273f8be42e724de370b1f1b2f0dae58a47010ef4c890d8cf5b8"
+              },
+              {
+                "alg": "SHA-384",
+                "content": "8147d3692b03ac84ccdd20f8ff7f3d319583434ad1a0178ab31d6433a3ed11c6e05967b26bbaf0420f400a32fb5941c5"
+              },
+              {
+                "alg": "SHA3-384",
+                "content": "899934416d5f5c3cfe0377b41d1403730c760b6d9edec6079e73a70ec8b92616055c37fb1fee3b227a6dae360cd9cc65"
+              },
+              {
+                "alg": "SHA3-256",
+                "content": "e57c428533d3222b66f93c6bd530ee3bd0e4584c32d5ad50424072f6e8de2d98"
+              },
+              {
+                "alg": "SHA3-512",
+                "content": "a6f07a263da0a69665d916d9b41f42d74061630c5ff83e8c407fa3b9aa47708c23a0a3c3c2b9f953af66b60374556c8e89eed2bb7ff3176fc4f603f957f0fffa"
+              }
+            ],
+            "licenses": [
+              {
+                "license": {
+                  "name": "Bouncy Castle Licence",
+                  "url": "http://www.bouncycastle.org/licence.html"
+                }
+              }
+            ],
+            "name": "bcpkix-jdk15on",
+            "purl": "pkg:maven/org.bouncycastle/bcpkix-jdk15on@1.56?type=jar",
+            "scope": "required",
+            "type": "framework",
+            "version": "1.56"
+          },
+          {
+            "bom-ref": "pkg:maven/org.springframework.cloud/spring-cloud-context@2.0.0.RELEASE?type=jar",
+            "description": "Spring Cloud Context",
+            "evidence": {
+              "identity": {
+                "confidence": 0.8,
+                "field": "purl",
+                "methods": [
+                  {
+                    "confidence": 0.8,
+                    "technique": "binary-analysis",
+                    "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\org\\springframework\\cloud\\spring-cloud-context\\2.0.0.RELEASE\\spring-cloud-context-2.0.0.RELEASE.jar"
+                  }
+                ]
+              },
+              "occurrences": [
+                {
+                  "location": "notification-service\\src\\main\\java\\com\\piggymetrics\\notification\\service\\EmailServiceImpl.java#22"
+                }
+              ]
+            },
+            "group": "org.springframework.cloud",
+            "hashes": [
+              {
+                "alg": "MD5",
+                "content": "e7a4e7275f373c6167b7590591c19efd"
+              },
+              {
+                "alg": "SHA-1",
+                "content": "3f0d28344c0dc74eb8594f3f3dd6f82c687be198"
+              },
+              {
+                "alg": "SHA-256",
+                "content": "abb111a850530a2d9174939f9ef6424efa4abecf978e5625915aa84ea17bb9fe"
+              },
+              {
+                "alg": "SHA-512",
+                "content": "c5bcf7518bb6bafc311af1e14db61f5fdcdb56e24658da1481e8806e5ad7c897e4def752b9af7d9df1e6cd998300f4f0881593e4b961827c33777c7cbcb6fb44"
+              },
+              {
+                "alg": "SHA-384",
+                "content": "96ff50360c1b03d6e225c5975405ce714464cacbbd77896c7841bbf47a14660970b13d2d11d7af1c7396ec4b0e9238e9"
+              },
+              {
+                "alg": "SHA3-384",
+                "content": "96c8275ce24cc07a8d9311075e667c44a1d9f032993e58be7f9632951a91744b96b118e5db3b0a9882f8d145a7e40f13"
+              },
+              {
+                "alg": "SHA3-256",
+                "content": "2074e427d7cda1199ef40962370de1dd1b3163c33ce9254a9e0b38a7667dc4bf"
+              },
+              {
+                "alg": "SHA3-512",
+                "content": "2f05d0c7c31bbac1336e5f37fdcdcdc7bf022a369faaa5c59a2733c8174022a7848492c8faad3fb483c7dce78210cc67465ce68b766b8155652d58d6f206149c"
+              }
+            ],
+            "licenses": [
+              {
+                "license": {
+                  "id": "Apache-2.0"
+                }
+              }
+            ],
+            "name": "spring-cloud-context",
+            "publisher": "Pivotal Software, Inc.",
+            "purl": "pkg:maven/org.springframework.cloud/spring-cloud-context@2.0.0.RELEASE?type=jar",
+            "scope": "required",
+            "type": "framework",
+            "version": "2.0.0.RELEASE"
+          },
+          {
+            "bom-ref": "pkg:maven/org.springframework.cloud/spring-cloud-starter@2.0.0.RELEASE?type=jar",
+            "description": "Spring Cloud Starter",
+            "evidence": {
+              "identity": {
+                "confidence": 0.8,
+                "field": "purl",
+                "methods": [
+                  {
+                    "confidence": 0.8,
+                    "technique": "binary-analysis",
+                    "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\org\\springframework\\cloud\\spring-cloud-starter\\2.0.0.RELEASE\\spring-cloud-starter-2.0.0.RELEASE.jar"
+                  }
+                ]
+              }
+            },
+            "group": "org.springframework.cloud",
+            "hashes": [
+              {
+                "alg": "MD5",
+                "content": "4d031dc9879546e189c6c914c19c0542"
+              },
+              {
+                "alg": "SHA-1",
+                "content": "0247ea27d9483e9806f539f6031af135a6a3645f"
+              },
+              {
+                "alg": "SHA-256",
+                "content": "670eedd14018f52145cd58de663739657a19e0e1a7ad965cf7e0a99dd37e84e4"
+              },
+              {
+                "alg": "SHA-512",
+                "content": "8187b1a499b98e9a2e44bdfa3bca5088ee8034bce371c014b5fd4b1c2240f3447562ba74987b3d91552d45e6c2349942342133ab6bc8e2ba4330257ad63b2f3b"
+              },
+              {
+                "alg": "SHA-384",
+                "content": "a42de307261711df91fd860690834edf0c28144e820ed8c513c3ec606ffc7728d3ff0496272b55944fbcce4ba7c79675"
+              },
+              {
+                "alg": "SHA3-384",
+                "content": "dba2c320469b2d423fae76fc68a0b57f4d5f7da17f2c7b44c41b7654bbb8395b7e669c538384728e2e65824e8864b501"
+              },
+              {
+                "alg": "SHA3-256",
+                "content": "d43f97976acafc9bcb47ccece04ef74ab61a6faddfea7ff5cae7c3c1acaedce5"
+              },
+              {
+                "alg": "SHA3-512",
+                "content": "5dc4e0e8e5f8e8154aeb362d6018a6d6d3507f4b3d60a3cf51d9ae80e17a9b5a300ff26ac1b508e1ab13c569ae572e94c443e4ca1c92edd48771a7fe5287b1bd"
+              }
+            ],
+            "licenses": [
+              {
+                "license": {
+                  "id": "Apache-2.0"
+                }
+              }
+            ],
+            "name": "spring-cloud-starter",
+            "publisher": "Pivotal Software, Inc.",
+            "purl": "pkg:maven/org.springframework.cloud/spring-cloud-starter@2.0.0.RELEASE?type=jar",
+            "scope": "required",
+            "type": "framework",
+            "version": "2.0.0.RELEASE"
+          },
+          {
+            "bom-ref": "pkg:maven/org.springframework.cloud/spring-cloud-starter-config@2.0.0.RELEASE?type=jar",
+            "description": "Spring Cloud Starter",
+            "evidence": {
+              "identity": {
+                "confidence": 0.8,
+                "field": "purl",
+                "methods": [
+                  {
+                    "confidence": 0.8,
+                    "technique": "binary-analysis",
+                    "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\org\\springframework\\cloud\\spring-cloud-starter-config\\2.0.0.RELEASE\\spring-cloud-starter-config-2.0.0.RELEASE.jar"
+                  }
+                ]
+              }
+            },
+            "group": "org.springframework.cloud",
+            "hashes": [
+              {
+                "alg": "MD5",
+                "content": "5d514c991ae9344ed41c50b6cce19bdc"
+              },
+              {
+                "alg": "SHA-1",
+                "content": "42f8c6a92ef1a09239e38a1cf65293ffde1b181c"
+              },
+              {
+                "alg": "SHA-256",
+                "content": "5342438a378e975b8ecd228eb33f527a96267ab75bd4e5c8a0bbdc729a9f95a9"
+              },
+              {
+                "alg": "SHA-512",
+                "content": "323078a561ef0cd2ab514801fe8604a3c16b2ae43c1bf92ad32d0abec780e0f9b557a781da1d6a9c56a225e77ef9cca3987246b3f43fbb7a5e2998caab392b8f"
+              },
+              {
+                "alg": "SHA-384",
+                "content": "d1c7ef45846e4bf3e0b69131d80102d5be8e9413d40a00aebecb4461ef59b06cd52c05ae68777592a9689713b92f64b7"
+              },
+              {
+                "alg": "SHA3-384",
+                "content": "eb6590405d9ff1dcf6b729bb561230598adf7893d61c1a46c5ae6f65974e3a3550b2b480628b656ea765be6fba9a8102"
+              },
+              {
+                "alg": "SHA3-256",
+                "content": "77acab1bc1c472b4f2d3dbadab3d278c827a967db51a6ca6d2046e1b6fc469f7"
+              },
+              {
+                "alg": "SHA3-512",
+                "content": "6736c58d38d47072eb084233062b0ea96b3b0ff66a4c4e8a4c2f3349d07a7091933abf05fda7a7660474520f7bb75c66d2c98fa9c488f98fe452d5dac132483a"
+              }
+            ],
+            "licenses": [
+              {
+                "license": {
+                  "id": "Apache-2.0"
+                }
+              }
+            ],
+            "name": "spring-cloud-starter-config",
+            "publisher": "Pivotal Software, Inc.",
+            "purl": "pkg:maven/org.springframework.cloud/spring-cloud-starter-config@2.0.0.RELEASE?type=jar",
+            "scope": "required",
+            "type": "framework",
+            "version": "2.0.0.RELEASE"
+          },
+          {
+            "bom-ref": "pkg:maven/org.springframework.security/spring-security-rsa@1.0.5.RELEASE?type=jar",
+            "description": "Spring Security RSA is a small utility library for RSA ciphers. It belongs to the family of Spring Security crypto libraries that handle encoding and decoding text as a general, useful thing to be able to do.",
+            "evidence": {
+              "callstack": {
+                "frames": [
+                  {
+                    "fullFilename": "auth-service\\src\\main\\java\\com\\piggymetrics\\auth\\config\\WebSecurityConfig.java",
+                    "function": "authenticationManagerBean",
+                    "line": 38,
+                    "module": "com.piggymetrics.auth.config.WebSecurityConfig",
+                    "package": "com.piggymetrics.auth.config"
+                  },
+                  {
+                    "column": 16,
+                    "fullFilename": "auth-service\\src\\main\\java\\com\\piggymetrics\\auth\\config\\WebSecurityConfig.java",
+                    "function": "authenticationManagerBean",
+                    "line": 41,
+                    "module": "com.piggymetrics.auth.config.WebSecurityConfig",
+                    "package": "com.piggymetrics.auth.config"
+                  },
+                  {
+                    "column": 16,
+                    "fullFilename": "auth-service\\src\\main\\java\\com\\piggymetrics\\auth\\config\\WebSecurityConfig.java",
+                    "function": "authenticationManagerBean",
+                    "line": 41,
+                    "module": "com.piggymetrics.auth.config.WebSecurityConfig",
+                    "package": "com.piggymetrics.auth.config"
+                  },
+                  {
+                    "column": 9,
+                    "fullFilename": "auth-service\\src\\main\\java\\com\\piggymetrics\\auth\\config\\WebSecurityConfig.java",
+                    "function": "authenticationManagerBean",
+                    "line": 41,
+                    "module": "com.piggymetrics.auth.config.WebSecurityConfig",
+                    "package": "com.piggymetrics.auth.config"
+                  }
+                ]
+              },
+              "identity": {
+                "confidence": 0.8,
+                "field": "purl",
+                "methods": [
+                  {
+                    "confidence": 0.8,
+                    "technique": "binary-analysis",
+                    "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\org\\springframework\\security\\spring-security-rsa\\1.0.5.RELEASE\\spring-security-rsa-1.0.5.RELEASE.jar"
+                  }
+                ]
+              }
+            },
+            "group": "org.springframework.security",
+            "hashes": [
+              {
+                "alg": "MD5",
+                "content": "88d25c857040132ad991af650dcb5e9e"
+              },
+              {
+                "alg": "SHA-1",
+                "content": "31bd1111ada2f455eb0f492ed09e39deda18ca99"
+              },
+              {
+                "alg": "SHA-256",
+                "content": "db764286a058f85ac06df00c254afd8d63c618db5abc962a6bdb5f440cb2e5d6"
+              },
+              {
+                "alg": "SHA-512",
+                "content": "9613e84294a7d0486d6f9529a614526b1b9e37c17c7a1f8c59baa418fe04eb5f09163ef31a7e29b59673bb899bfeaa1d9b99daf91a70dec0a3f761e12da7c284"
+              },
+              {
+                "alg": "SHA-384",
+                "content": "74af3ef26d098d1c4954e5c4d8cf19391ea1788eaa06cf4d4176d7fd7008d7b34ef594e384c480966cf3e6fd1a57df9e"
+              },
+              {
+                "alg": "SHA3-384",
+                "content": "ae5b96fd3c5ef3c12bfc91cd6b74fea4d0371ebeed79ff8de1c219b6689ed878c3dde01fb90c34a0163681d234e7a9d2"
+              },
+              {
+                "alg": "SHA3-256",
+                "content": "cfb4a0c1fee534a26992a7f7adf569b07b5e1190338adf77639afd384c20f2d3"
+              },
+              {
+                "alg": "SHA3-512",
+                "content": "60338f31c9984f232abb52affe0025bb4f8380a71b754d8f5f686360339985d6015f995299d73a8cf4a9eac743cfc9cc141b9de0c672d4743b2740539b497e0a"
+              }
+            ],
+            "licenses": [
+              {
+                "license": {
+                  "id": "Apache-2.0"
+                }
+              }
+            ],
+            "name": "spring-security-rsa",
+            "publisher": "SpringSource",
+            "purl": "pkg:maven/org.springframework.security/spring-security-rsa@1.0.5.RELEASE?type=jar",
+            "scope": "required",
+            "type": "framework",
+            "version": "1.0.5.RELEASE"
+          }
+        ],
+        "applications": [],
+        "other_types": []
+      },
+      "misc_data": {
+        "bomFormat": "CycloneDX",
+        "metadata": {
+          "authors": [
+            {
+              "name": "OWASP Foundation"
+            }
+          ],
+          "component": {
+            "bom-ref": "pkg:maven/com.piggymetrics/turbine-stream-service@0.0.1-SNAPSHOT?type=jar",
+            "description": "Turbine Stream Service",
+            "externalReferences": [
+              {
+                "type": "vcs",
+                "url": "https://github.com/spring-projects/spring-boot/spring-boot-starter-parent/piggymetrics/turbine-stream-service"
+              },
+              {
+                "type": "website",
+                "url": "https://projects.spring.io/spring-boot/#/spring-boot-starter-parent/piggymetrics/turbine-stream-service"
+              }
+            ],
+            "group": "com.piggymetrics",
+            "licenses": [
+              {
+                "license": {
+                  "id": "Apache-2.0"
+                }
+              }
+            ],
+            "name": "turbine-stream-service",
+            "purl": "pkg:maven/com.piggymetrics/turbine-stream-service@0.0.1-SNAPSHOT?type=jar",
+            "type": "library",
+            "version": "0.0.1-SNAPSHOT"
+          },
+          "tools": {
+            "components": [
+              {
+                "author": "OWASP Foundation",
+                "group": "@cyclonedx",
+                "name": "cdxgen",
+                "publisher": "OWASP Foundation",
+                "type": "application"
+              }
+            ]
+          }
+        },
+        "specVersion": "1.5",
+        "version": 3
+      },
+      "services": [
+        {
+          "authenticated": true,
+          "endpoints": [
+            "/uaa/users"
+          ],
+          "name": "com-piggymetrics-account-client-AuthServiceClient-createUser-service",
+          "x-trust-boundary": true
+        },
+        {
+          "endpoints": [
+            "/statistics/{accountName}"
+          ],
+          "name": "com-piggymetrics-account-client-StatisticsServiceClient-updateStatistics-service"
+        },
+        {
+          "endpoints": [
+            "/"
+          ],
+          "name": "com-piggymetrics-account-controller-AccountController-createNewAccount-service"
+        },
+        {
+          "endpoints": [
+            "/current"
+          ],
+          "name": "com-piggymetrics-statistics-controller-StatisticsController-getCurrentAccountStatistics-service"
+        },
+        {
+          "authenticated": true,
+          "endpoints": [
+            "/{accountName}"
+          ],
+          "name": "com-piggymetrics-statistics-controller-StatisticsController-getStatisticsByAccountName-service",
+          "x-trust-boundary": true
+        },
+        {
+          "authenticated": true,
+          "endpoints": [
+            "/{accountName}"
+          ],
+          "name": "com-piggymetrics-statistics-controller-StatisticsController-saveAccountStatistics-service",
+          "x-trust-boundary": true
+        }
+      ],
+      "dependencies": [
+        {
+          "ref": "pkg:maven/com.piggymetrics/turbine-stream-service@0.0.1-SNAPSHOT?type=jar",
+          "dependsOn": [
+            "pkg:maven/org.springframework.boot/spring-boot-starter-test@2.0.3.RELEASE?type=jar",
+            "pkg:maven/org.springframework.cloud/spring-cloud-starter-config@2.0.0.RELEASE?type=jar",
+            "pkg:maven/org.springframework.cloud/spring-cloud-starter-netflix-eureka-client@2.0.0.RELEASE?type=jar",
+            "pkg:maven/org.springframework.cloud/spring-cloud-starter-netflix-turbine-stream@2.0.0.RELEASE?type=jar",
+            "pkg:maven/org.springframework.cloud/spring-cloud-starter-stream-rabbit@2.0.0.RELEASE?type=jar"
+          ]
+        },
+        {
+          "ref": "pkg:maven/org.springframework.boot/spring-boot-starter@2.0.3.RELEASE?type=jar",
+          "dependsOn": [
+            "pkg:maven/javax.annotation/javax.annotation-api@1.3.2?type=jar",
+            "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.0.3.RELEASE?type=jar",
+            "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.0.3.RELEASE?type=jar",
+            "pkg:maven/org.springframework.boot/spring-boot@2.0.3.RELEASE?type=jar",
+            "pkg:maven/org.springframework/spring-core@5.0.7.RELEASE?type=jar",
+            "pkg:maven/org.yaml/snakeyaml@1.19?type=jar"
+          ]
+        },
+        {
+          "ref": "pkg:maven/org.springframework.cloud/spring-cloud-starter-config@2.0.0.RELEASE?type=jar",
+          "dependsOn": [
+            "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.6?type=jar",
+            "pkg:maven/org.springframework.cloud/spring-cloud-config-client@2.0.0.RELEASE?type=jar",
+            "pkg:maven/org.springframework.cloud/spring-cloud-starter@2.0.0.RELEASE?type=jar"
+          ]
+        },
+        {
+          "ref": "pkg:maven/org.springframework.cloud/spring-cloud-starter@2.0.0.RELEASE?type=jar",
+          "dependsOn": [
+            "pkg:maven/org.springframework.boot/spring-boot-starter@2.0.3.RELEASE?type=jar",
+            "pkg:maven/org.springframework.cloud/spring-cloud-commons@2.0.0.RELEASE?type=jar",
+            "pkg:maven/org.springframework.cloud/spring-cloud-context@2.0.0.RELEASE?type=jar",
+            "pkg:maven/org.springframework.security/spring-security-rsa@1.0.5.RELEASE?type=jar"
+          ]
+        }
+      ]
+    },
+    "diff_summary": {
+      "test/sbom-java2.json": {
+        "components": {
+          "libraries": [
+            {
+              "bom-ref": "pkg:maven/com.piggymetrics/turbine-stream-service@0.0.1-SNAPSHOT?type=jar",
+              "description": "Turbine Stream Service",
+              "group": "com.piggymetrics",
+              "licenses": [
+                {
+                  "license": {
+                    "id": "Apache-2.0"
+                  }
+                }
+              ],
+              "name": "turbine-stream-service",
+              "purl": "pkg:maven/com.piggymetrics/turbine-stream-service@0.0.1-SNAPSHOT?type=jar",
+              "type": "library",
+              "version": "0.0.1-SNAPSHOT"
+            }
+          ],
+          "frameworks": [
+            {
+              "bom-ref": "pkg:maven/javax.activation/activation@1.1?type=jar",
+              "description": "JavaBeans Activation Framework (JAF) is a standard extension to the Java platform that lets you take advantage of standard services to: determine the type of an arbitrary piece of data; encapsulate access to it; discover the operations available on it; and instantiate the appropriate bean to perform the operation(s).",
+              "evidence": {
+                "identity": {
+                  "confidence": 0.8,
+                  "field": "purl",
+                  "methods": [
+                    {
+                      "confidence": 0.8,
+                      "technique": "binary-analysis",
+                      "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\javax\\activation\\activation\\1.1\\activation-1.1.jar"
+                    }
+                  ]
+                }
+              },
+              "group": "javax.activation",
+              "hashes": [
+                {
+                  "alg": "MD5",
+                  "content": "8ae38e87cd4f86059c0294a8fe3e0b18"
+                },
+                {
+                  "alg": "SHA-1",
+                  "content": "e6cb541461c2834bdea3eb920f1884d1eb508b50"
+                },
+                {
+                  "alg": "SHA-256",
+                  "content": "2881c79c9d6ef01c58e62beea13e9d1ac8b8baa16f2fc198ad6e6776defdcdd3"
+                },
+                {
+                  "alg": "SHA-512",
+                  "content": "c0ff5bf3ace7acc1b31fcc109cee48d9eb8f025ae15a31dc91eca760933bdb97c93f05d61e95af1e317859d72e5f179f897f5bf3df0e3810f4212d43bacee4bd"
+                },
+                {
+                  "alg": "SHA-384",
+                  "content": "c4ee54d80a2e67e819700051d6cfa01a17631c89f942b8690afb601e491f02d7497fe57bd5c70edfb9b444ae8222b846"
+                },
+                {
+                  "alg": "SHA3-384",
+                  "content": "de0777d2d1d7aad105defb12aed17ef38abfe89db2449c5243fa3c69304ea24dd8df0881330351d0733313e8f7252814"
+                },
+                {
+                  "alg": "SHA3-256",
+                  "content": "5fb94d2742cc3d44abad42c5d61b9c7464a2ef33bc58b4b5b121d49799123460"
+                },
+                {
+                  "alg": "SHA3-512",
+                  "content": "c5e37fe3d9c420a9035f1160eb1d396e94f01851c01c6e2f19f19a221bfc484e63f9660c7377f58aa65246b95a9eb799ac4e6798c0b20f658edf00a4435e1efa"
+                }
+              ],
+              "licenses": [
+                {
+                  "license": {
+                    "id": "CDDL-1.0"
+                  }
+                }
+              ],
+              "name": "activation",
+              "purl": "pkg:maven/javax.activation/activation@1.1?type=jar",
+              "scope": "required",
+              "type": "framework",
+              "version": "1.1"
+            }
+          ],
+          "applications": [],
+          "other_types": []
+        },
+        "misc_data": {},
+        "dependencies": [
+          {
+            "ref": "pkg:maven/javax.activation/activation@1.1?type=jar",
+            "dependsOn": []
+          }
+        ]
+      },
+      "test/sbom-java.json": {
+        "components": {
+          "libraries": [
+            {
+              "bom-ref": "pkg:maven/commons-jxpath/commons-jxpath@1.3?type=jar",
+              "description": "A Java-based implementation of XPath 1.0 that, in addition to XML processing, can inspect/modify Java object graphs (the library's explicit purpose) and even mixed Java/XML structures.",
+              "evidence": {
+                "identity": {
+                  "confidence": 0.8,
+                  "field": "purl",
+                  "methods": [
+                    {
+                      "confidence": 0.8,
+                      "technique": "binary-analysis",
+                      "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\commons-jxpath\\commons-jxpath\\1.3\\commons-jxpath-1.3.jar"
+                    }
+                  ]
+                }
+              },
+              "group": "commons-jxpath",
+              "hashes": [
+                {
+                  "alg": "MD5",
+                  "content": "61a9aa8ff43ba10853571d57f724bf88"
+                },
+                {
+                  "alg": "SHA-1",
+                  "content": "c22d7d0f0f40eb7059a23cfa61773a416768b137"
+                },
+                {
+                  "alg": "SHA-256",
+                  "content": "fcbc0ad917d9d6a73c6df21fac322e00d213ef19cd94815a007c407a8a3ff449"
+                },
+                {
+                  "alg": "SHA-512",
+                  "content": "351c5f6af0711a955e5d839551833015956812765e9dc35e78bfd7c99656f1ecec5cf6587469229688340f00c2b5d07917993ccb0809561e0dd35b4ffb074d93"
+                },
+                {
+                  "alg": "SHA-384",
+                  "content": "327139dac9f672ffa772480a754ec6c3125a3057faf7911188a34cc52d088770efe8464bb303e2347be7f55303d24493"
+                },
+                {
+                  "alg": "SHA3-384",
+                  "content": "b2913b137433bfc2fe78ed57dc44de5737410947e809c0b8bb1d6a83ad333069e41fd97167c20e9fd3a052c2a7dfa9b8"
+                },
+                {
+                  "alg": "SHA3-256",
+                  "content": "3bbafe102ece8be037419a214a524f0c52fa0c3455322d3c2633f1c075e9efbc"
+                },
+                {
+                  "alg": "SHA3-512",
+                  "content": "e050591ecd10746ffee670e1e95a53afa8b43b01164c3ae581bce9ee0a5410eece3f71d05175486eb4d186de88d5defeebef52730939611951ca1cd50ec978a7"
+                }
+              ],
+              "licenses": [
+                {
+                  "license": {
+                    "id": "Apache-2.0"
+                  }
+                }
+              ],
+              "name": "commons-jxpath",
+              "publisher": "The Apache Software Foundation",
+              "purl": "pkg:maven/commons-jxpath/commons-jxpath@1.3?type=jar",
+              "scope": "required",
+              "type": "library",
+              "version": "1.3"
+            },
+            {
+              "bom-ref": "pkg:maven/com.netflix.eureka/eureka-client@1.9.2?type=jar",
+              "description": "eureka-client",
+              "evidence": {
+                "identity": {
+                  "confidence": 0.8,
+                  "field": "purl",
+                  "methods": [
+                    {
+                      "confidence": 0.8,
+                      "technique": "binary-analysis",
+                      "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\com\\netflix\\eureka\\eureka-client\\1.9.2\\eureka-client-1.9.2.jar"
+                    }
+                  ]
+                }
+              },
+              "group": "com.netflix.eureka",
+              "hashes": [
+                {
+                  "alg": "MD5",
+                  "content": "f1a16ca3654e743409bb60c47eb02f01"
+                },
+                {
+                  "alg": "SHA-1",
+                  "content": "47c0b71d8face149833c4958ac7b3b6171861f4c"
+                },
+                {
+                  "alg": "SHA-256",
+                  "content": "279fc7616a9c0c904dd11ba53aaeec0790d35511cbda2a81e8606b6c6a13c7f3"
+                },
+                {
+                  "alg": "SHA-512",
+                  "content": "3abb8075ff7ece646f8ae62c840a8b79b1163741a41e84a7dd7af939f554c6e2f9057ca901d10fe639b693fb9223a2f74bce00743b421a9263acdb246eeee7cb"
+                },
+                {
+                  "alg": "SHA-384",
+                  "content": "99475120ea6b3ca18098f3346fe2a7ca539a472d2110e0aedf96d941403a1f37049df31785d1e4e3257adf44d0a5630a"
+                },
+                {
+                  "alg": "SHA3-384",
+                  "content": "b7a195e9f54f4189c8e27624ba44c5ff191ffe977d6e70ffc6d1795a4f4d4d3869d15992e555eed71cb427f744fd3b9b"
+                },
+                {
+                  "alg": "SHA3-256",
+                  "content": "2ed92d790b33a71dcc8de331d77bdde3c823ced8521ad0cd6e1f75430fdb04bf"
+                },
+                {
+                  "alg": "SHA3-512",
+                  "content": "b0f8d56fa259be87844612709b83ba3611548215d405ecd02220a22e1539d2666a5cf37b51ca618291f92dbb007dfd4a6dfa037905bfd0d313b8221cc2605c5b"
+                }
+              ],
+              "licenses": [
+                {
+                  "license": {
+                    "id": "Apache-2.0"
+                  }
+                }
+              ],
+              "name": "eureka-client",
+              "purl": "pkg:maven/com.netflix.eureka/eureka-client@1.9.2?type=jar",
+              "scope": "required",
+              "type": "library",
+              "version": "1.9.2"
+            },
+            {
+              "bom-ref": "pkg:maven/com.google.code.gson/gson@2.8.5?type=jar",
+              "description": "Gson JSON library",
+              "evidence": {
+                "identity": {
+                  "confidence": 0.8,
+                  "field": "purl",
+                  "methods": [
+                    {
+                      "confidence": 0.8,
+                      "technique": "binary-analysis",
+                      "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\com\\google\\code\\gson\\gson\\2.8.5\\gson-2.8.5.jar"
+                    }
+                  ]
+                }
+              },
+              "group": "com.google.code.gson",
+              "hashes": [
+                {
+                  "alg": "MD5",
+                  "content": "089104cb90d8b4e1aa00b1f5faef0742"
+                },
+                {
+                  "alg": "SHA-1",
+                  "content": "f645ed69d595b24d4cf8b3fbb64cc505bede8829"
+                },
+                {
+                  "alg": "SHA-256",
+                  "content": "233a0149fc365c9f6edbd683cfe266b19bdc773be98eabdaf6b3c924b48e7d81"
+                },
+                {
+                  "alg": "SHA-512",
+                  "content": "5dd7214c542a7b93aab3eab0ba13e4ac3d6ddb05c795fb6d3992e21925a98dce87cb186ac67b4d3ad146f96e14d38b3892837eca57a27b4e845aca6d4e4f708a"
+                },
+                {
+                  "alg": "SHA-384",
+                  "content": "77f4d6efe8d9cf78b72f34e439035d266db1b82c9d96e6b78e6c571d4c719bb5f2b78e8377263280c6cc9dffe18b3d16"
+                },
+                {
+                  "alg": "SHA3-384",
+                  "content": "953e2eca6de4a05e1cf86a9750aa9f1d10bfd06a15f7eaab4a59716cbec74a7bf6c5f421b1752d487882954daecc5781"
+                },
+                {
+                  "alg": "SHA3-256",
+                  "content": "94cde12c15a685a10309653cfef73d14d09b340f1b8f0a9a04267136e9bf2820"
+                },
+                {
+                  "alg": "SHA3-512",
+                  "content": "0aed985c19435fb6d5e04a79a7553f56a66814157ac93addcb24f9286321d0063b69ac008501f0e22f691ecb15a50491d3313aee73a745286454817e2f410fe9"
+                }
+              ],
+              "licenses": [
+                {
+                  "license": {
+                    "id": "Apache-2.0"
+                  }
+                }
+              ],
+              "name": "gson",
+              "purl": "pkg:maven/com.google.code.gson/gson@2.8.5?type=jar",
+              "scope": "required",
+              "type": "library",
+              "version": "2.8.5"
+            },
+            {
+              "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.9.0?type=jar",
+              "description": "Core annotations used for value types, used by Jackson data binding package.",
+              "evidence": {
+                "identity": {
+                  "confidence": 0.8,
+                  "field": "purl",
+                  "methods": [
+                    {
+                      "confidence": 0.8,
+                      "technique": "binary-analysis",
+                      "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\com\\fasterxml\\jackson\\core\\jackson-annotations\\2.9.0\\jackson-annotations-2.9.0.jar"
+                    }
+                  ]
+                },
+                "occurrences": [
+                  {
+                    "location": "statistics-service\\src\\main\\java\\com\\piggymetrics\\statistics\\domain\\ExchangeRatesContainer.java#9"
+                  }
+                ]
+              },
+              "group": "com.fasterxml.jackson.core",
+              "hashes": [
+                {
+                  "alg": "MD5",
+                  "content": "c09faa1b063681cf45706c6df50685b6"
+                },
+                {
+                  "alg": "SHA-1",
+                  "content": "07c10d545325e3a6e72e06381afe469fd40eb701"
+                },
+                {
+                  "alg": "SHA-256",
+                  "content": "45d32ac61ef8a744b464c54c2b3414be571016dd46bfc2bec226761cf7ae457a"
+                },
+                {
+                  "alg": "SHA-512",
+                  "content": "266589c36ea544ebca94aecd76ba9dfe88637563b94cf24e46846466b103074c9f95508bfa237c20d0ab9c60bfb6befa2628236dcf7222a69cf1ef9462bcf0b3"
+                },
+                {
+                  "alg": "SHA-384",
+                  "content": "36289e4a5d6774c4fc6ed38a632a681759a4bc0389616a79edd22298dbcbe8f1bc7a107f00a9ec76b492d125c890a939"
+                },
+                {
+                  "alg": "SHA3-384",
+                  "content": "d575397eff488d8b2e2098f1bcc8c0a7d49a3c0532ecec9c2996709576cf9fffe967f421dab2c4d2e280867efefd71af"
+                },
+                {
+                  "alg": "SHA3-256",
+                  "content": "5ad4c52561d43e8f80798256ae39449955b2d34376d3fbb9f354f9fcb61f477a"
+                },
+                {
+                  "alg": "SHA3-512",
+                  "content": "8322ba66c29bfa8152a4c6294f6c3350d7a59fce154ba9db8624e369085aae42585addf864f373d250f76e5678b5967ecac79aff9255d96e5c109f310424f208"
+                }
+              ],
+              "licenses": [
+                {
+                  "license": {
+                    "id": "Apache-2.0"
+                  }
+                }
+              ],
+              "name": "jackson-annotations",
+              "publisher": "FasterXML",
+              "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.9.0?type=jar",
+              "scope": "required",
+              "type": "library",
+              "version": "2.9.0"
+            },
+            {
+              "bom-ref": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.6?type=jar",
+              "description": "General data-binding functionality for Jackson: works on core streaming API",
+              "evidence": {
+                "identity": {
+                  "confidence": 0.8,
+                  "field": "purl",
+                  "methods": [
+                    {
+                      "confidence": 0.8,
+                      "technique": "binary-analysis",
+                      "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\com\\fasterxml\\jackson\\core\\jackson-databind\\2.9.6\\jackson-databind-2.9.6.jar"
+                    }
+                  ]
+                },
+                "occurrences": [
+                  {
+                    "location": "account-service\\src\\test\\java\\com\\piggymetrics\\account\\controller\\AccountControllerTest.java#114"
+                  },
+                  {
+                    "location": "account-service\\src\\test\\java\\com\\piggymetrics\\account\\controller\\AccountControllerTest.java#118"
+                  },
+                  {
+                    "location": "account-service\\src\\test\\java\\com\\piggymetrics\\account\\controller\\AccountControllerTest.java#131"
+                  },
+                  {
+                    "location": "account-service\\src\\test\\java\\com\\piggymetrics\\account\\controller\\AccountControllerTest.java#143"
+                  },
+                  {
+                    "location": "auth-service\\src\\test\\java\\com\\piggymetrics\\auth\\controller\\UserControllerTest.java#51"
+                  },
+                  {
+                    "location": "notification-service\\src\\test\\java\\com\\piggymetrics\\notification\\controller\\RecipientControllerTest.java#53"
+                  },
+                  {
+                    "location": "statistics-service\\src\\test\\java\\com\\piggymetrics\\statistics\\controller\\StatisticsControllerTest.java#114"
+                  }
+                ]
+              },
+              "group": "com.fasterxml.jackson.core",
+              "hashes": [
+                {
+                  "alg": "MD5",
+                  "content": "c6634d654c2df15a987bc37ec8d2b6b2"
+                },
+                {
+                  "alg": "SHA-1",
+                  "content": "cfa4f316351a91bfd95cb0644c6a2c95f52db1fc"
+                },
+                {
+                  "alg": "SHA-256",
+                  "content": "657e3e979446d61f88432b9c50f0ccd9c1fe4f1c822d533f5572e4c0d172a125"
+                },
+                {
+                  "alg": "SHA-512",
+                  "content": "f0861f775e2aebd61df8a39419f959b61019af7b307812b92beb14d7a234edeaf09c054fbb24a1432f4dd0c726b7d2b535bdc3ecb8b3d00b661e01d4d46ec4be"
+                },
+                {
+                  "alg": "SHA-384",
+                  "content": "80682058957cb75863d94f0ed223dc69cad95526e41b80d2810bfb04308c6fbd4bf4df90f43edacd8f820d43296b61ea"
+                },
+                {
+                  "alg": "SHA3-384",
+                  "content": "a5682de7a39422fde523ad1d6fe2db75a4a390266692362e296115e06e07e515cb6b85598ada103e54031dbefc5ea7f3"
+                },
+                {
+                  "alg": "SHA3-256",
+                  "content": "885a3161af0a28a56a7d41631034921b846f9b1b0e02062e0758b17337026bdf"
+                },
+                {
+                  "alg": "SHA3-512",
+                  "content": "480f9d8a7e5c2cb7ff981b3e004708dd632f8c472a8da3114486499a15a4bfa21ee4904e4ac5f0d1aef4dccd19fc95ceb1f9f6d5a65ea13ca2a7d9815585f82e"
+                }
+              ],
+              "licenses": [
+                {
+                  "license": {
+                    "id": "Apache-2.0"
+                  }
+                }
+              ],
+              "name": "jackson-databind",
+              "publisher": "FasterXML",
+              "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.6?type=jar",
+              "scope": "required",
+              "type": "library",
+              "version": "2.9.6"
+            },
+            {
+              "bom-ref": "pkg:maven/org.codehaus.jettison/jettison@1.3.7?type=jar",
+              "description": "A StAX implementation for JSON.",
+              "evidence": {
+                "identity": {
+                  "confidence": 0.8,
+                  "field": "purl",
+                  "methods": [
+                    {
+                      "confidence": 0.8,
+                      "technique": "binary-analysis",
+                      "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\org\\codehaus\\jettison\\jettison\\1.3.7\\jettison-1.3.7.jar"
+                    }
+                  ]
+                }
+              },
+              "group": "org.codehaus.jettison",
+              "hashes": [
+                {
+                  "alg": "MD5",
+                  "content": "c1ce879e927ca435da0fd2fd6c8a6b60"
+                },
+                {
+                  "alg": "SHA-1",
+                  "content": "7d36a59a0577f11b12088b9e215d6860345b9e1d"
+                },
+                {
+                  "alg": "SHA-256",
+                  "content": "b39e77d92f5a682c639c8962980499e6be34b5c9fda7ad4dba3b5fd9e99b5070"
+                },
+                {
+                  "alg": "SHA-512",
+                  "content": "1304499b9951cba15f10486a061d91ec91efec7aa039162d5fa3d4effb60596fd1c73152fa46d170bbe065d98718f4c9354403bcee7aa3acd03d7b03aa45eeee"
+                },
+                {
+                  "alg": "SHA-384",
+                  "content": "4cf5155094f09370f72e94768d6f1429662fb6dcfe6df00f91d78977d42a61dd62d51f1464d3d79eb7363ded95f53474"
+                },
+                {
+                  "alg": "SHA3-384",
+                  "content": "5e88aeeb907a6b304a2125a01b55549633b64ce7a43469eff7fdb82ad9e3dfe2e48696c8fd184b2cec6e6062dd1079eb"
+                },
+                {
+                  "alg": "SHA3-256",
+                  "content": "e8c94791fa652fbc24dbd55ce3fb3ad3cc703d576f935a4b4d2710148615cf9c"
+                },
+                {
+                  "alg": "SHA3-512",
+                  "content": "c75a5dc446297a1eaac02f36829ea2891ffa5e9a3ca45a888f935d8cd65e6f3cab9c6410b45b36987c23674c243b9d6f0d4371f9efec92b70b92a4355732c329"
+                }
+              ],
+              "licenses": [
+                {
+                  "license": {
+                    "id": "Apache-2.0"
+                  }
+                }
+              ],
+              "name": "jettison",
+              "purl": "pkg:maven/org.codehaus.jettison/jettison@1.3.7?type=jar",
+              "scope": "required",
+              "type": "library",
+              "version": "1.3.7"
+            },
+            {
+              "bom-ref": "pkg:maven/joda-time/joda-time@2.9.9?type=jar",
+              "description": "Date and time library to replace JDK date handling",
+              "evidence": {
+                "identity": {
+                  "confidence": 0.8,
+                  "field": "purl",
+                  "methods": [
+                    {
+                      "confidence": 0.8,
+                      "technique": "binary-analysis",
+                      "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\joda-time\\joda-time\\2.9.9\\joda-time-2.9.9.jar"
+                    }
+                  ]
+                }
+              },
+              "group": "joda-time",
+              "hashes": [
+                {
+                  "alg": "MD5",
+                  "content": "eca438c8cc2b1de38e28d884b7f15dbc"
+                },
+                {
+                  "alg": "SHA-1",
+                  "content": "f7b520c458572890807d143670c9b24f4de90897"
+                },
+                {
+                  "alg": "SHA-256",
+                  "content": "b049a43c1057942e6acfbece008e4949b2e35d1658d0c8e06f4485397e2fa4e7"
+                },
+                {
+                  "alg": "SHA-512",
+                  "content": "3a6749ecd71ee8d5781821c36d77850a810e72ee33757ec4ee9e3d424676dced7eeb955a432f45edb3694dc14dbe1ee4c608545d6a445b29b86979a7c9829384"
+                },
+                {
+                  "alg": "SHA-384",
+                  "content": "76fadb1a66e6e6f9780aef2ca6ecfe6e07c0abb0829cc436c0ebf02186ba571219a290ec4bf1b510059594b146d39eff"
+                },
+                {
+                  "alg": "SHA3-384",
+                  "content": "9f4b85b886cd0b78b1404522979c0bd150dfe27f01469a17e943d35f5fad2de37fd88f35c0f0d49613c81a6fc0a8cd6b"
+                },
+                {
+                  "alg": "SHA3-256",
+                  "content": "22837a75e07c2c56cb3565e324f157f0850f9df62471293af3a77ec2ad456535"
+                },
+                {
+                  "alg": "SHA3-512",
+                  "content": "b7f8c9cac6086a5c7d861e5dfa9a42c1191ae17e9d9bfbae5eea2e1f6e25eb084fcb9bdc6bbb7d9c693d423452c9533b1216648793d5ca31675af23d1a0f0397"
+                }
+              ],
+              "licenses": [
+                {
+                  "license": {
+                    "id": "Apache-2.0"
+                  }
+                }
+              ],
+              "name": "joda-time",
+              "publisher": "Joda.org",
+              "purl": "pkg:maven/joda-time/joda-time@2.9.9?type=jar",
+              "scope": "required",
+              "type": "library",
+              "version": "2.9.9"
+            },
+            {
+              "bom-ref": "pkg:maven/com.netflix.netflix-commons/netflix-eventbus@0.3.0?type=jar",
+              "description": "netflix-eventbus",
+              "evidence": {
+                "identity": {
+                  "confidence": 0.8,
+                  "field": "purl",
+                  "methods": [
+                    {
+                      "confidence": 0.8,
+                      "technique": "binary-analysis",
+                      "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\com\\netflix\\netflix-commons\\netflix-eventbus\\0.3.0\\netflix-eventbus-0.3.0.jar"
+                    }
+                  ]
+                }
+              },
+              "group": "com.netflix.netflix-commons",
+              "hashes": [
+                {
+                  "alg": "MD5",
+                  "content": "8ad05394a13f658a67d1e4cbf0359402"
+                },
+                {
+                  "alg": "SHA-1",
+                  "content": "3f864adbe81f0849729fcbba3fe693c32be739ea"
+                },
+                {
+                  "alg": "SHA-256",
+                  "content": "387bce0906f22c285ed96bcc520a7581d6abbc418b6c3c1e45a4530eb97d94b1"
+                },
+                {
+                  "alg": "SHA-512",
+                  "content": "94a6efc1be744e281211f7856037c057863ad67ee1a45bd4cfc1adbb15216a6cb20ba0d54caa26d902f653efe496098b5e71eb5b2c466b10deb94af7559f67a0"
+                },
+                {
+                  "alg": "SHA-384",
+                  "content": "192c415c11edbc320d0d7b2f41c485bae7dbc20d9f406d0b05a5d02436a005a72d4dc015190748749ac74314f20c496b"
+                },
+                {
+                  "alg": "SHA3-384",
+                  "content": "d8580812de33ef27de8dc91205cf56b2aec19572fcfc7fd49e723ed17e4eb4d853f99627417bd9bd30f1cd7de24b4dcf"
+                },
+                {
+                  "alg": "SHA3-256",
+                  "content": "840ce15c01ed37b974b4c5ab4a75d539afb6c43cad90437504d23884864735d5"
+                },
+                {
+                  "alg": "SHA3-512",
+                  "content": "13549ecc52b63986900eefd48441f78687a5ac0f89d752752f3c973e7d664607785a6b8850ef7ab6181cc4f90580301cc0a19f2fc694e3f97d9776bd43f416e9"
+                }
+              ],
+              "licenses": [
+                {
+                  "license": {
+                    "id": "Apache-2.0"
+                  }
+                }
+              ],
+              "name": "netflix-eventbus",
+              "purl": "pkg:maven/com.netflix.netflix-commons/netflix-eventbus@0.3.0?type=jar",
+              "scope": "required",
+              "type": "library",
+              "version": "0.3.0"
+            },
+            {
+              "bom-ref": "pkg:maven/com.netflix.netflix-commons/netflix-infix@0.3.0?type=jar",
+              "description": "netflix-infix",
+              "evidence": {
+                "identity": {
+                  "confidence": 0.8,
+                  "field": "purl",
+                  "methods": [
+                    {
+                      "confidence": 0.8,
+                      "technique": "binary-analysis",
+                      "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\com\\netflix\\netflix-commons\\netflix-infix\\0.3.0\\netflix-infix-0.3.0.jar"
+                    }
+                  ]
+                }
+              },
+              "group": "com.netflix.netflix-commons",
+              "hashes": [
+                {
+                  "alg": "MD5",
+                  "content": "3410072887ca26fc0b7e71a7e91f8e2b"
+                },
+                {
+                  "alg": "SHA-1",
+                  "content": "acc65969f7367ddd2f1265e0cd7330509ed530dc"
+                },
+                {
+                  "alg": "SHA-256",
+                  "content": "7dec45215c262c4f0a42c1f3adb8613788cf43c6ed21274e15c73ea5500d2597"
+                },
+                {
+                  "alg": "SHA-512",
+                  "content": "477278c1d16d6753a1a2acdb0edd8189b069db1828dd34d808985b48924257e0971ec190bf6efafb14b962e3e0158f2221c195a83fe9bd38fb1574e6cdbf90d3"
+                },
+                {
+                  "alg": "SHA-384",
+                  "content": "185629545fd32a7b890c4318cb7979f0475fa42e54039c80105c4eb20efbe5eabf0338ab59256440fc6366e9bc84d0e4"
+                },
+                {
+                  "alg": "SHA3-384",
+                  "content": "7aa7b6c88a89c3324677846543b54b5151d45370d48309a529e492576c64174958f22564ed0d5b88a24d5b0696554326"
+                },
+                {
+                  "alg": "SHA3-256",
+                  "content": "14f1ba7c66c7b18a45bb2949f784d9028911bdf80376e1553bd9ed6d15083720"
+                },
+                {
+                  "alg": "SHA3-512",
+                  "content": "e0b9054727385449f0d29062959eed8ca5f4dec126b85c82fd04155b136ecdf5a4dc1cb78b837f5ff3b86f72b3241d4507f0d4008f519aced1ff2637eb6df3c5"
+                }
+              ],
+              "licenses": [
+                {
+                  "license": {
+                    "id": "Apache-2.0"
+                  }
+                }
+              ],
+              "name": "netflix-infix",
+              "purl": "pkg:maven/com.netflix.netflix-commons/netflix-infix@0.3.0?type=jar",
+              "scope": "required",
+              "type": "library",
+              "version": "0.3.0"
+            },
+            {
+              "bom-ref": "pkg:maven/stax/stax-api@1.0.1?type=jar",
+              "description": "StAX API is the standard java XML processing API defined by JSR-173",
+              "evidence": {
+                "identity": {
+                  "confidence": 0.8,
+                  "field": "purl",
+                  "methods": [
+                    {
+                      "confidence": 0.8,
+                      "technique": "binary-analysis",
+                      "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\stax\\stax-api\\1.0.1\\stax-api-1.0.1.jar"
+                    }
+                  ]
+                }
+              },
+              "group": "stax",
+              "hashes": [
+                {
+                  "alg": "MD5",
+                  "content": "7d436a53c64490bee564c576babb36b4"
+                },
+                {
+                  "alg": "SHA-1",
+                  "content": "49c100caf72d658aca8e58bd74a4ba90fa2b0d70"
+                },
+                {
+                  "alg": "SHA-256",
+                  "content": "d1968436fc216c901fb9b82c7e878b50fd1d30091676da95b2edd3a9c0ccf92e"
+                },
+                {
+                  "alg": "SHA-512",
+                  "content": "43c24e8dbffa9b932492c8ccf2b91926b2ba3d1d34b5a9671c689bd24d4c220b996708a9667521641d1abbf29404b653755b6f6f3dc0ad0671f5c09db332ea06"
+                },
+                {
+                  "alg": "SHA-384",
+                  "content": "2e6c232d3012064dc17e10c2e5b281728a6771eb0d74868e730caf60fe6f96fdd6145759fbbf9d1aa2e07eb1f49764d6"
+                },
+                {
+                  "alg": "SHA3-384",
+                  "content": "03ebb8db88d04b7308570c1058aadfb6a81d3d6725b1dd13a049ea984ed1df42d3e0f8163e1229752228cada978fb462"
+                },
+                {
+                  "alg": "SHA3-256",
+                  "content": "8173e3e3a0db17b3dbb80c017268858ecda57c819e5b58dbe202bd8087664bb1"
+                },
+                {
+                  "alg": "SHA3-512",
+                  "content": "e9a7c234dfeff5d4cabd034a536f31ad5a141e30b0ad2438cf5856dd6c36eeb16c69b8bc1ba3ee6bba91f69cd3cbd450953249f2f0eee0a9a22d49637b575f4d"
+                }
+              ],
+              "licenses": [
+                {
+                  "license": {
+                    "id": "Apache-2.0"
+                  }
+                }
+              ],
+              "name": "stax-api",
+              "purl": "pkg:maven/stax/stax-api@1.0.1?type=jar",
+              "scope": "required",
+              "type": "library",
+              "version": "1.0.1"
+            },
+            {
+              "bom-ref": "pkg:maven/org.antlr/stringtemplate@3.2.1?type=jar",
+              "description": "StringTemplate is a java template engine for generating source code, web pages, emails, or any other formatted text output. StringTemplate is particularly good at multi-targeted code generators, multiple site skins, and internationalization/localization. It evolved over years of effort developing jGuru.com. StringTemplate also generates the stringtemplate website: http://www.stringtemplate.org and powers the ANTLR v3 code generator. Its distinguishing characteristic is that unlike other engines, it strictly enforces model-view separation. Strict separation makes websites and code generators more flexible and maintainable; it also provides an excellent defense against malicious template authors. There are currently about 600 StringTemplate source downloads a month.",
+              "evidence": {
+                "identity": {
+                  "confidence": 0.8,
+                  "field": "purl",
+                  "methods": [
+                    {
+                      "confidence": 0.8,
+                      "technique": "binary-analysis",
+                      "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\org\\antlr\\stringtemplate\\3.2.1\\stringtemplate-3.2.1.jar"
+                    }
+                  ]
+                }
+              },
+              "group": "org.antlr",
+              "hashes": [
+                {
+                  "alg": "MD5",
+                  "content": "b58ca53e518a92a1991eb63b61917582"
+                },
+                {
+                  "alg": "SHA-1",
+                  "content": "59ec8083721eae215c6f3caee944c410d2be34de"
+                },
+                {
+                  "alg": "SHA-256",
+                  "content": "f66ce72e965e5301cb0f020e54d2ba6ad76feb91b3cbfc30dbbf00c06a6df6d7"
+                },
+                {
+                  "alg": "SHA-512",
+                  "content": "47f3cfd91906b527b615fd10d27387aafa9f355aa9c18a86861c975091c39895b711fe514ed1597dabe6af2a2705dfc45bb70fb5e30f5d428a48e0d1b02b7856"
+                },
+                {
+                  "alg": "SHA-384",
+                  "content": "a12c2a95e162207835a2a785f2dfccd4b3d9d9b94741d1b3e171ff04699afc920c549425115c63a95c7941ead3909edf"
+                },
+                {
+                  "alg": "SHA3-384",
+                  "content": "d9ccd03170058316ea8c98142afbecb7a3b357dda5cd1253c9b57810449048fae7d79e93d5ba74cb901bd765429d8714"
+                },
+                {
+                  "alg": "SHA3-256",
+                  "content": "6181e67482392f97de747d04dc11418e54ca77888d1d1f6925563fe6a2c1633b"
+                },
+                {
+                  "alg": "SHA3-512",
+                  "content": "e75331f732a6c9e280f04438db65c47aa2efb4b07980ad3ce5e227693b47c5959d87e40590e19552f67dc257cc4f187a35ee112e850a6bda9d9e69bba2dba34c"
+                }
+              ],
+              "licenses": [
+                {
+                  "license": {
+                    "name": "BSD licence",
+                    "url": "http://antlr.org/license.html"
+                  }
+                }
+              ],
+              "name": "stringtemplate",
+              "purl": "pkg:maven/org.antlr/stringtemplate@3.2.1?type=jar",
+              "scope": "required",
+              "type": "library",
+              "version": "3.2.1"
+            }
+          ],
+          "frameworks": [
+            {
+              "bom-ref": "pkg:maven/antlr/antlr@2.7.7?type=jar",
+              "description": "A framework for constructing recognizers, compilers, and translators from grammatical descriptions containing Java, C#, C++, or Python actions.",
+              "evidence": {
+                "identity": {
+                  "confidence": 0.8,
+                  "field": "purl",
+                  "methods": [
+                    {
+                      "confidence": 0.8,
+                      "technique": "binary-analysis",
+                      "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\antlr\\antlr\\2.7.7\\antlr-2.7.7.jar"
+                    }
+                  ]
+                }
+              },
+              "group": "antlr",
+              "hashes": [
+                {
+                  "alg": "MD5",
+                  "content": "f8f1352c52a4c6a500b597596501fc64"
+                },
+                {
+                  "alg": "SHA-1",
+                  "content": "83cd2cd674a217ade95a4bb83a8a14f351f48bd0"
+                },
+                {
+                  "alg": "SHA-256",
+                  "content": "88fbda4b912596b9f56e8e12e580cc954bacfb51776ecfddd3e18fc1cf56dc4c"
+                },
+                {
+                  "alg": "SHA-512",
+                  "content": "311c3115f9f6651d1711c52d1739e25a70f25456cacb9a2cdde7627498c30b13d721133cc75b39462ad18812a82472ef1b3b9d64fab5abb0377c12bf82043a74"
+                },
+                {
+                  "alg": "SHA-384",
+                  "content": "2e811e531ce30a2a905d093a00de596cf04406413b60422db8252b46125cadf07b71459cf6ac6da575ec030a9bf05e57"
+                },
+                {
+                  "alg": "SHA3-384",
+                  "content": "bdf019332ae8714ef6a3904bb42bb08c1fe4feacf5e6137274884b0377d4e5b5f7aa9fe8e1ef5ca9b3e15f12320fdb67"
+                },
+                {
+                  "alg": "SHA3-256",
+                  "content": "babce5c8beb1d5907a7ed6354589e991da7d8d5cbd86c479abfa1e1dfc4d2eb8"
+                },
+                {
+                  "alg": "SHA3-512",
+                  "content": "3a8ce565280a157dd6e08fb68c317a4c28616099c56bc4992c38cf74a10a54a89e18e7c45190ce8511360798a87adc92f432382f9d9bdde0d56664b50044b517"
+                }
+              ],
+              "licenses": [
+                {
+                  "license": {
+                    "id": "BSD-3-Clause"
+                  }
+                }
+              ],
+              "name": "antlr",
+              "purl": "pkg:maven/antlr/antlr@2.7.7?type=jar",
+              "scope": "required",
+              "type": "framework",
+              "version": "2.7.7"
+            },
+            {
+              "bom-ref": "pkg:maven/org.antlr/antlr-runtime@3.4?type=jar",
+              "description": "A framework for constructing recognizers, compilers, and translators from grammatical descriptions containing Java, C#, C++, or Python actions.",
+              "evidence": {
+                "identity": {
+                  "confidence": 0.8,
+                  "field": "purl",
+                  "methods": [
+                    {
+                      "confidence": 0.8,
+                      "technique": "binary-analysis",
+                      "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\org\\antlr\\antlr-runtime\\3.4\\antlr-runtime-3.4.jar"
+                    }
+                  ]
+                }
+              },
+              "group": "org.antlr",
+              "hashes": [
+                {
+                  "alg": "MD5",
+                  "content": "0e0318be407e51fdf7ba6777eabfdf73"
+                },
+                {
+                  "alg": "SHA-1",
+                  "content": "8f011408269a8e42b8548687e137d8eeb56df4b4"
+                },
+                {
+                  "alg": "SHA-256",
+                  "content": "5b7cf53b7b30b034023f58030c8147c433f2bee0fe7dec8fae6bebf3708c5a63"
+                },
+                {
+                  "alg": "SHA-512",
+                  "content": "1786aff2df4664483adcb319e64be7b69b643ac9508c3f11796b5aa45b9072b46f53f0a21b2ff7291162afe81506de16161746273e4532ebad75adbd81203f0d"
+                },
+                {
+                  "alg": "SHA-384",
+                  "content": "6ee2dcd3cf8366fe6ee18fb87aebe2d162b232c89e0aab417f97fed368cdf652d27db518dc5e71aa2a4aadda2e7f4c7a"
+                },
+                {
+                  "alg": "SHA3-384",
+                  "content": "db284c93203cbbec1b22b482a45c70c68e858a90e73b23fae66c1bc53231b0f61c5576fcf51ea0d3a30070428d7dd865"
+                },
+                {
+                  "alg": "SHA3-256",
+                  "content": "3f6cf631e9f792a41128400f8690266d915c0588ef85073a6cae73624a155b10"
+                },
+                {
+                  "alg": "SHA3-512",
+                  "content": "13d1f73c44e807b36946c21cfd506e91e8cbdf685b770cbc0dcb4e55ec28b5bc91bd90eb7f24ebfd13386a47eccf552dd2a1ab277fccabafdb7a9b40aa9d4fc5"
+                }
+              ],
+              "licenses": [],
+              "name": "antlr-runtime",
+              "purl": "pkg:maven/org.antlr/antlr-runtime@3.4?type=jar",
+              "scope": "required",
+              "type": "framework",
+              "version": "3.4"
+            },
+            {
+              "bom-ref": "pkg:maven/org.bouncycastle/bcprov-jdk15on@1.56?type=jar",
+              "description": "The Bouncy Castle Crypto package is a Java implementation of cryptographic algorithms. This jar contains JCE provider and lightweight API for the Bouncy Castle Cryptography APIs for JDK 1.5 to JDK 1.8.",
+              "evidence": {
+                "identity": {
+                  "confidence": 0.8,
+                  "field": "purl",
+                  "methods": [
+                    {
+                      "confidence": 0.8,
+                      "technique": "binary-analysis",
+                      "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\org\\bouncycastle\\bcprov-jdk15on\\1.56\\bcprov-jdk15on-1.56.jar"
+                    }
+                  ]
+                }
+              },
+              "group": "org.bouncycastle",
+              "hashes": [
+                {
+                  "alg": "MD5",
+                  "content": "3c1bc7aaf3449308e34296546078d9f7"
+                },
+                {
+                  "alg": "SHA-1",
+                  "content": "a153c6f9744a3e9dd6feab5e210e1c9861362ec7"
+                },
+                {
+                  "alg": "SHA-256",
+                  "content": "963e1ee14f808ffb99897d848ddcdb28fa91ddda867eb18d303e82728f878349"
+                },
+                {
+                  "alg": "SHA-512",
+                  "content": "47e5f73d2b66891cf21412b807481fff4b1a844ff247ba170e7bab25a7f6303cbd5ada22e7382ba20ee344d8cc3a1909a3d255f4b24defe9357523b4a122db68"
+                },
+                {
+                  "alg": "SHA-384",
+                  "content": "c9de4efe55d8737d5c84e7253cabe2de7b7d72180ef4c0a645ede19f627d3ebce7c0c4f19e51412b7e0a16d6c6255d32"
+                },
+                {
+                  "alg": "SHA3-384",
+                  "content": "ef69f74fbf1f5416c90038f07aad6aa83e60932cf8a31400554e0380c134921ed8638528b4339edd5e8b7d1df4f62a3f"
+                },
+                {
+                  "alg": "SHA3-256",
+                  "content": "ab4e77030ace3c79f45602cf94baf81ae18305ae83037c5a37077a752cb5bfab"
+                },
+                {
+                  "alg": "SHA3-512",
+                  "content": "24ea4d76cc78baecafd8baeae0e201201463d920c102fe20f8dd29ff307785194dc27323215dd24680b77bbb1e65841f8150f047a3b8f007c9b04f4860b4a181"
+                }
+              ],
+              "licenses": [
+                {
+                  "license": {
+                    "name": "Bouncy Castle Licence",
+                    "url": "http://www.bouncycastle.org/licence.html"
+                  }
+                }
+              ],
+              "name": "bcprov-jdk15on",
+              "purl": "pkg:maven/org.bouncycastle/bcprov-jdk15on@1.56?type=jar",
+              "scope": "required",
+              "type": "framework",
+              "version": "1.56"
+            },
+            {
+              "bom-ref": "pkg:maven/org.apache.commons/commons-math@2.2?type=jar",
+              "description": "The Math project is a library of lightweight, self-contained mathematics and statistics components addressing the most common practical problems not immediately available in the Java programming language or commons-lang.",
+              "evidence": {
+                "identity": {
+                  "confidence": 0.8,
+                  "field": "purl",
+                  "methods": [
+                    {
+                      "confidence": 0.8,
+                      "technique": "binary-analysis",
+                      "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\org\\apache\\commons\\commons-math\\2.2\\commons-math-2.2.jar"
+                    }
+                  ]
+                }
+              },
+              "group": "org.apache.commons",
+              "hashes": [
+                {
+                  "alg": "MD5",
+                  "content": "4b65633769a2d3c532c86188648bb380"
+                },
+                {
+                  "alg": "SHA-1",
+                  "content": "4877b85d388275f994a5cfc7eceb73a8045d3006"
+                },
+                {
+                  "alg": "SHA-256",
+                  "content": "15993bb2a3cf50f3291b40fc980a3166a0984e7b5f1abbe5232151fd94954584"
+                },
+                {
+                  "alg": "SHA-512",
+                  "content": "f444ead8d025d92ebacc05a366cdfd6f3c9b9788f36961cc66a4c71846b9e953a586268c23268a7a8b9561159fc38f7478daea8142b3b55fb3a8dea756720ab6"
+                },
+                {
+                  "alg": "SHA-384",
+                  "content": "56dde9ba9689a3efae9165010b08469108f4971542809b52facc348a841dbed76d83b5fe218ca24db6d8276f45e39458"
+                },
+                {
+                  "alg": "SHA3-384",
+                  "content": "7d71fdb235d8d8c4019164315b6241e893215ee3ed4934a15ccc71bae9154726e8e9ec1ab76daf0e8dec62d0069e806d"
+                },
+                {
+                  "alg": "SHA3-256",
+                  "content": "d00d7bef766c466c34e0f624a1ba6ea6a2c1a0a46de81f85e331548d13b5cef0"
+                },
+                {
+                  "alg": "SHA3-512",
+                  "content": "67bcc94b3d2ebf1e8d9862ad5c57609e6315e53fb27f9db16be4e1384a6619aee9e7f2d2ef530380e107d9c337cbcd4bb3a21ff4293931cb9bb488f598c63b5c"
+                }
+              ],
+              "licenses": [
+                {
+                  "license": {
+                    "id": "Apache-2.0"
+                  }
+                }
+              ],
+              "name": "commons-math",
+              "publisher": "The Apache Software Foundation",
+              "purl": "pkg:maven/org.apache.commons/commons-math@2.2?type=jar",
+              "scope": "required",
+              "type": "framework",
+              "version": "2.2"
+            },
+            {
+              "bom-ref": "pkg:maven/org.springframework/spring-aop@5.0.7.RELEASE?type=jar",
+              "description": "Spring AOP",
+              "evidence": {
+                "identity": {
+                  "confidence": 0.8,
+                  "field": "purl",
+                  "methods": [
+                    {
+                      "confidence": 0.8,
+                      "technique": "binary-analysis",
+                      "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\org\\springframework\\spring-aop\\5.0.7.RELEASE\\spring-aop-5.0.7.RELEASE.jar"
+                    }
+                  ]
+                }
+              },
+              "group": "org.springframework",
+              "hashes": [
+                {
+                  "alg": "MD5",
+                  "content": "cd592093caba2866661a095786f1ed11"
+                },
+                {
+                  "alg": "SHA-1",
+                  "content": "fdd0b6aa3c9c7a188c3bfbf6dfd8d40e843be9ef"
+                },
+                {
+                  "alg": "SHA-256",
+                  "content": "2de906598bfb44d3e6833c36e1ad9c565275af16da25e13e6f676126f613908c"
+                },
+                {
+                  "alg": "SHA-512",
+                  "content": "24ba927d8ea0ca58a8a6722fe99ed165b7174926a3f2ac731eaa8383e7f6b9f74caf7ae39562ef9ee324914ccf8ad5b6b7270bfc688a461c6feed089e778dffb"
+                },
+                {
+                  "alg": "SHA-384",
+                  "content": "67209dd624bfaa95f376772e89f0e574b971d9224a2c5ca91645a9a00b3e25ab8c4594e96ac7de09c2ac111767ec39ad"
+                },
+                {
+                  "alg": "SHA3-384",
+                  "content": "e5a7367855624bc08bbf442cece3b894a285068b7a328e3451818fda2d9a148678c736a18d98eef1a6490587329015f2"
+                },
+                {
+                  "alg": "SHA3-256",
+                  "content": "3f0c5849b9b772b3544611b78300843d6751fac5bf80dbec44a07d0fb95bb75c"
+                },
+                {
+                  "alg": "SHA3-512",
+                  "content": "e3871a6dea5b1a64cc8fba9b05a48a83b3924190f9eab5d576583ec9060cbf1982133f845360f0aa2f05cd9dab6b00a6e5f5dff5d8a33914848fff9bfe0f63d4"
+                }
+              ],
+              "licenses": [
+                {
+                  "license": {
+                    "id": "Apache-2.0"
+                  }
+                }
+              ],
+              "name": "spring-aop",
+              "publisher": "Spring IO",
+              "purl": "pkg:maven/org.springframework/spring-aop@5.0.7.RELEASE?type=jar",
+              "scope": "required",
+              "type": "framework",
+              "version": "5.0.7.RELEASE"
+            },
+            {
+              "bom-ref": "pkg:maven/org.springframework/spring-beans@5.0.7.RELEASE?type=jar",
+              "description": "Spring Beans",
+              "evidence": {
+                "identity": {
+                  "confidence": 0.8,
+                  "field": "purl",
+                  "methods": [
+                    {
+                      "confidence": 0.8,
+                      "technique": "binary-analysis",
+                      "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\org\\springframework\\spring-beans\\5.0.7.RELEASE\\spring-beans-5.0.7.RELEASE.jar"
+                    }
+                  ]
+                },
+                "occurrences": [
+                  {
+                    "location": "account-service\\src\\main\\java\\com\\piggymetrics\\account\\config\\ResourceServerConfig.java#28"
+                  }
+                ]
+              },
+              "group": "org.springframework",
+              "hashes": [
+                {
+                  "alg": "MD5",
+                  "content": "c850badbb984cda6983da22c8672a59f"
+                },
+                {
+                  "alg": "SHA-1",
+                  "content": "c1196cb3e56da83e3c3a02ef323699f4b05feedc"
+                },
+                {
+                  "alg": "SHA-256",
+                  "content": "0d0adc1832406304985a72d2c79c6d0af481f34ae2a9c4a3835c9b0968da25e3"
+                },
+                {
+                  "alg": "SHA-512",
+                  "content": "58b8e141981594d43cc52fd179f512a1919eaa4ddd323127302fd753b5befb1b5ee8fc3b70adf4963bdaa181ac3ff67ed643bdacdde2881c26f12f55d3c34190"
+                },
+                {
+                  "alg": "SHA-384",
+                  "content": "d2aaea6cd85065710cdc27d25dfd7bdfdea57f0f796214767e83f09b967c6cb2c954369a40e2e6f55f4106b43d099558"
+                },
+                {
+                  "alg": "SHA3-384",
+                  "content": "f35b746798ceaad156b257f6c208cc3e9783244d68501187af355a98613c048b62cee350b728c67fc067ddca41fabbe1"
+                },
+                {
+                  "alg": "SHA3-256",
+                  "content": "72ae91c81771a542fb4ce30b45608b43dcfe03d9e18070763e7421fa0389d52c"
+                },
+                {
+                  "alg": "SHA3-512",
+                  "content": "ecb8c1471d73b885db4b4796a95a1af1e229f33724f2d3cbdf8df947f84fd1dcc6064a8ef2552189304df475283c9c899d4bcb3bdf3a0f97390aed50d0f8815b"
+                }
+              ],
+              "licenses": [
+                {
+                  "license": {
+                    "id": "Apache-2.0"
+                  }
+                }
+              ],
+              "name": "spring-beans",
+              "publisher": "Spring IO",
+              "purl": "pkg:maven/org.springframework/spring-beans@5.0.7.RELEASE?type=jar",
+              "scope": "required",
+              "type": "framework",
+              "version": "5.0.7.RELEASE"
+            },
+            {
+              "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.0.3.RELEASE?type=jar",
+              "description": "Spring Boot AutoConfigure",
+              "evidence": {
+                "callstack": {
+                  "frames": [
+                    {
+                      "fullFilename": "statistics-service\\src\\main\\java\\com\\piggymetrics\\statistics\\config\\ResourceServerConfig.java",
+                      "function": "tokenServices",
+                      "line": 21,
+                      "module": "com.piggymetrics.statistics.config.ResourceServerConfig",
+                      "package": "com.piggymetrics.statistics.config"
+                    },
+                    {
+                      "column": 48,
+                      "fullFilename": "statistics-service\\src\\main\\java\\com\\piggymetrics\\statistics\\config\\ResourceServerConfig.java",
+                      "function": "tokenServices",
+                      "line": 23,
+                      "module": "com.piggymetrics.statistics.config.ResourceServerConfig",
+                      "package": "com.piggymetrics.statistics.config"
+                    },
+                    {
+                      "column": 70,
+                      "fullFilename": "statistics-service\\src\\main\\java\\com\\piggymetrics\\statistics\\config\\ResourceServerConfig.java",
+                      "function": "tokenServices",
+                      "line": 23,
+                      "module": "com.piggymetrics.statistics.config.ResourceServerConfig",
+                      "package": "com.piggymetrics.statistics.config"
+                    },
+                    {
+                      "column": 70,
+                      "fullFilename": "statistics-service\\src\\main\\java\\com\\piggymetrics\\statistics\\config\\ResourceServerConfig.java",
+                      "function": "tokenServices",
+                      "line": 23,
+                      "module": "com.piggymetrics.statistics.config.ResourceServerConfig",
+                      "package": "com.piggymetrics.statistics.config"
+                    },
+                    {
+                      "column": 65,
+                      "fullFilename": "statistics-service\\src\\main\\java\\com\\piggymetrics\\statistics\\service\\security\\CustomUserInfoTokenServices.java",
+                      "function": "<init>",
+                      "line": 46,
+                      "module": "com.piggymetrics.statistics.service.security.CustomUserInfoTokenServices",
+                      "package": "com.piggymetrics.statistics.service.security"
+                    },
+                    {
+                      "column": 19,
+                      "fullFilename": "statistics-service\\src\\main\\java\\com\\piggymetrics\\statistics\\service\\security\\CustomUserInfoTokenServices.java",
+                      "function": "<init>",
+                      "line": 48,
+                      "module": "com.piggymetrics.statistics.service.security.CustomUserInfoTokenServices",
+                      "package": "com.piggymetrics.statistics.service.security"
+                    },
+                    {
+                      "column": 3,
+                      "fullFilename": "statistics-service\\src\\main\\java\\com\\piggymetrics\\statistics\\service\\security\\CustomUserInfoTokenServices.java",
+                      "function": "<init>",
+                      "line": 48,
+                      "module": "com.piggymetrics.statistics.service.security.CustomUserInfoTokenServices",
+                      "package": "com.piggymetrics.statistics.service.security"
+                    },
+                    {
+                      "fullFilename": "statistics-service\\src\\main\\java\\com\\piggymetrics\\statistics\\service\\security\\CustomUserInfoTokenServices.java",
+                      "function": "<init>",
+                      "line": 46,
+                      "module": "",
+                      "package": ""
+                    },
+                    {
+                      "fullFilename": "statistics-service\\src\\main\\java\\com\\piggymetrics\\statistics\\config\\ResourceServerConfig.java",
+                      "function": "tokenServices",
+                      "module": "com.piggymetrics.statistics.config.ResourceServerConfig",
+                      "package": "com.piggymetrics.statistics.config"
+                    },
+                    {
+                      "column": 9,
+                      "fullFilename": "statistics-service\\src\\main\\java\\com\\piggymetrics\\statistics\\config\\ResourceServerConfig.java",
+                      "function": "tokenServices",
+                      "line": 23,
+                      "module": "com.piggymetrics.statistics.config.ResourceServerConfig",
+                      "package": "com.piggymetrics.statistics.config"
+                    }
+                  ]
+                },
+                "identity": {
+                  "confidence": 0.8,
+                  "field": "purl",
+                  "methods": [
+                    {
+                      "confidence": 0.8,
+                      "technique": "binary-analysis",
+                      "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\org\\springframework\\boot\\spring-boot-autoconfigure\\2.0.3.RELEASE\\spring-boot-autoconfigure-2.0.3.RELEASE.jar"
+                    }
+                  ]
+                },
+                "occurrences": [
+                  {
+                    "location": "account-service\\src\\main\\java\\com\\piggymetrics\\account\\AccountApplication.java#11"
+                  },
+                  {
+                    "location": "auth-service\\src\\main\\java\\com\\piggymetrics\\auth\\AuthApplication.java#9"
+                  },
+                  {
+                    "location": "config\\src\\main\\java\\com\\piggymetrics\\config\\ConfigApplication.java#7"
+                  },
+                  {
+                    "location": "gateway\\src\\main\\java\\com\\piggymetrics\\gateway\\GatewayApplication.java#8"
+                  },
+                  {
+                    "location": "monitoring\\src\\main\\java\\com\\piggymetrics\\monitoring\\MonitoringApplication.java#7"
+                  },
+                  {
+                    "location": "notification-service\\src\\main\\java\\com\\piggymetrics\\notification\\NotificationServiceApplication.java#18"
+                  },
+                  {
+                    "location": "registry\\src\\main\\java\\com\\piggymetrics\\registry\\RegistryApplication.java#7"
+                  },
+                  {
+                    "location": "statistics-service\\src\\main\\java\\com\\piggymetrics\\statistics\\StatisticsApplication.java#21"
+                  },
+                  {
+                    "location": "turbine-stream-service\\src\\main\\java\\com\\piggymetrics\\turbine\\TurbineStreamServiceApplication.java#8"
+                  }
+                ]
+              },
+              "group": "org.springframework.boot",
+              "hashes": [
+                {
+                  "alg": "MD5",
+                  "content": "0a52980d8c71d372ee9c6b100da7f49b"
+                },
+                {
+                  "alg": "SHA-1",
+                  "content": "011bc4cc96b08fabad2b3186755818fa0b32d83f"
+                },
+                {
+                  "alg": "SHA-256",
+                  "content": "742df8010f51ac98a14ff19fbd6df1ef0aca7656ad475295fa90444389d2d9d4"
+                },
+                {
+                  "alg": "SHA-512",
+                  "content": "c2918394ff63ad616f64fd2900cc1c688f8772cf05a3f206d2521e2ab525bda29f6e87b18ca7ae4c4c6cd4a248032d51cc0a0d4806370166efbabc77173caac2"
+                },
+                {
+                  "alg": "SHA-384",
+                  "content": "cad79a4a727581de121cc68864c456863f396e85adc7b1514bae5f874b5a50ce134ce7723c1697e297d4c61b29dcbd5c"
+                },
+                {
+                  "alg": "SHA3-384",
+                  "content": "5bfb3d163cfaaa467d760860d0c0e3825c1bccf2b62626822eb0eaa272bec13798b09b4137b109c58836c3d7566af73d"
+                },
+                {
+                  "alg": "SHA3-256",
+                  "content": "7d51c2f934ca270814c03cb35422d183a5fd16cce3b7a707047f7e1ae610b099"
+                },
+                {
+                  "alg": "SHA3-512",
+                  "content": "e057673f1fe4b86b0b3bd60d2feeef09549bd373cfd56e8d8a88b13272f8824b87bc8cfd02fb9739b1456ffa82567e1e99ca3cf6d5c1b7954cd0a0aa8f4d4299"
+                }
+              ],
+              "licenses": [
+                {
+                  "license": {
+                    "id": "Apache-2.0"
+                  }
+                }
+              ],
+              "name": "spring-boot-autoconfigure",
+              "publisher": "Pivotal Software, Inc.",
+              "purl": "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.0.3.RELEASE?type=jar",
+              "scope": "required",
+              "type": "framework",
+              "version": "2.0.3.RELEASE"
+            },
+            {
+              "bom-ref": "pkg:maven/org.springframework.boot/spring-boot-starter-aop@2.0.3.RELEASE?type=jar",
+              "description": "Starter for aspect-oriented programming with Spring AOP and AspectJ",
+              "evidence": {
+                "identity": {
+                  "confidence": 0.8,
+                  "field": "purl",
+                  "methods": [
+                    {
+                      "confidence": 0.8,
+                      "technique": "binary-analysis",
+                      "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\org\\springframework\\boot\\spring-boot-starter-aop\\2.0.3.RELEASE\\spring-boot-starter-aop-2.0.3.RELEASE.jar"
+                    }
+                  ]
+                }
+              },
+              "group": "org.springframework.boot",
+              "hashes": [
+                {
+                  "alg": "MD5",
+                  "content": "0c857777c2044cd2ececee6b70c1cef5"
+                },
+                {
+                  "alg": "SHA-1",
+                  "content": "a78c7bc25fd51b217f078421dc40d13ddc3b9f8f"
+                },
+                {
+                  "alg": "SHA-256",
+                  "content": "ddfc437ff26e206e74d8d2b949a978dc39a5bfdade596ab280a9d56efff2d5b1"
+                },
+                {
+                  "alg": "SHA-512",
+                  "content": "329768326aa539dbdfda2d7eb79798deccc00948c05a6029159e25058832374789465df103da18fc88a949a08d0c439dde93b7383237106b7b92aac742f2a674"
+                },
+                {
+                  "alg": "SHA-384",
+                  "content": "c6cd2c55f39efda38caf74099d2340b02d853c47cf688d66ca8fbcdbd674b1a9725d5553899f2c0ab5c65f5f11c41f10"
+                },
+                {
+                  "alg": "SHA3-384",
+                  "content": "040f344c92763062c6fa2a6de1de4b07d4156db2e6a1b10189af28887a5dcd70a6b8eb505f953910310baaf42c9a06c1"
+                },
+                {
+                  "alg": "SHA3-256",
+                  "content": "0b2ef68be5c3f07c5a385ca24cbf50cacffe25f38eb440df5bb2ea9e79d10ff3"
+                },
+                {
+                  "alg": "SHA3-512",
+                  "content": "ef3aecc2f2545c8224dff5e7dec998b3a2d94c6bb6296b08cf732f8488336431cd152cc15007ddb062cff00e465d9b288205dcbace1bab3859f069748d597674"
+                }
+              ],
+              "licenses": [
+                {
+                  "license": {
+                    "id": "Apache-2.0"
+                  }
+                }
+              ],
+              "name": "spring-boot-starter-aop",
+              "publisher": "Pivotal Software, Inc.",
+              "purl": "pkg:maven/org.springframework.boot/spring-boot-starter-aop@2.0.3.RELEASE?type=jar",
+              "scope": "required",
+              "type": "framework",
+              "version": "2.0.3.RELEASE"
+            },
+            {
+              "bom-ref": "pkg:maven/org.springframework.cloud/spring-cloud-config-client@2.0.0.RELEASE?type=jar",
+              "description": "This project is a Spring configuration client.",
+              "evidence": {
+                "identity": {
+                  "confidence": 0.8,
+                  "field": "purl",
+                  "methods": [
+                    {
+                      "confidence": 0.8,
+                      "technique": "binary-analysis",
+                      "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\org\\springframework\\cloud\\spring-cloud-config-client\\2.0.0.RELEASE\\spring-cloud-config-client-2.0.0.RELEASE.jar"
+                    }
+                  ]
+                }
+              },
+              "group": "org.springframework.cloud",
+              "hashes": [
+                {
+                  "alg": "MD5",
+                  "content": "5f479b27ddaa0d47f0cc6e150ac05c33"
+                },
+                {
+                  "alg": "SHA-1",
+                  "content": "7a3f4447664c61ff674c29a9b2ff0dc988dee316"
+                },
+                {
+                  "alg": "SHA-256",
+                  "content": "a4c26aaa864418c008b3fb067ad3b54da9a968921db4bab47366b97bd8f8ca30"
+                },
+                {
+                  "alg": "SHA-512",
+                  "content": "b545b2744f31d5cc8fd7cf89e42bf7dc1a4464d1761d28f48f7446906c6bd43ec2a696eac0ba2708723ebee36b1f6316f37972e24b76eb1a621f0f153779d4ea"
+                },
+                {
+                  "alg": "SHA-384",
+                  "content": "15b9e5813ca5260a888248932b83b3e63cd27bf46ac5db0091718c7c6e91e5d78d7889da0b1fdbaaa12de74e0fdedc49"
+                },
+                {
+                  "alg": "SHA3-384",
+                  "content": "48ae1e40ca060c109ce89ae48eba68bb348f05aaab6f074aec8c969b66e7b3a811e8bc6e8901c183c14085612bb01dfa"
+                },
+                {
+                  "alg": "SHA3-256",
+                  "content": "263ebd750a961f58776b4cf085feb28381530eace5b8c75d9011eeb19a2bb98d"
+                },
+                {
+                  "alg": "SHA3-512",
+                  "content": "3d3fd94e8f281be0c4d8059dfd199ac117afba71bbd777c412f7ec7c2937a2e0caa9f01197948f9df1ebb854e0082c7dc3881bf0b7f599607444c3d4bd3016dd"
+                }
+              ],
+              "licenses": [
+                {
+                  "license": {
+                    "id": "Apache-2.0"
+                  }
+                }
+              ],
+              "name": "spring-cloud-config-client",
+              "publisher": "Pivotal Software, Inc.",
+              "purl": "pkg:maven/org.springframework.cloud/spring-cloud-config-client@2.0.0.RELEASE?type=jar",
+              "scope": "required",
+              "type": "framework",
+              "version": "2.0.0.RELEASE"
+            },
+            {
+              "bom-ref": "pkg:maven/org.springframework.cloud/spring-cloud-netflix-core@2.0.0.RELEASE?type=jar",
+              "description": "Spring Cloud Netflix Core",
+              "evidence": {
+                "identity": {
+                  "confidence": 0.8,
+                  "field": "purl",
+                  "methods": [
+                    {
+                      "confidence": 0.8,
+                      "technique": "binary-analysis",
+                      "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\org\\springframework\\cloud\\spring-cloud-netflix-core\\2.0.0.RELEASE\\spring-cloud-netflix-core-2.0.0.RELEASE.jar"
+                    }
+                  ]
+                }
+              },
+              "group": "org.springframework.cloud",
+              "hashes": [
+                {
+                  "alg": "MD5",
+                  "content": "2070a3bc6e5b770d52cdd65858ddda07"
+                },
+                {
+                  "alg": "SHA-1",
+                  "content": "796bf4e966fac782c2118396d5504e01d5bd3115"
+                },
+                {
+                  "alg": "SHA-256",
+                  "content": "8651ad06e6c91fadd5bf77fba528b9a23a66fb3b57b495ea8da20def6f3b5f6e"
+                },
+                {
+                  "alg": "SHA-512",
+                  "content": "7814ad392c384ba4186f164e8b663e600a90c577de54ac89b967126cfe462ce08a2f295f7e54f94db3902f49de8838c70faec413d78a2d23a339a609cadcd41c"
+                },
+                {
+                  "alg": "SHA-384",
+                  "content": "accd2bb47510f90c7df339cca211b5bf66321df9fdd5a157ed23adc012cd1f914cd94c4174cacb3e641b748ea4275e25"
+                },
+                {
+                  "alg": "SHA3-384",
+                  "content": "77e17180e15dca51e4f3d69ff91cc90467f772d014c7a826595b5e1892a0f57bc4b4e037a59495558fefa71764fd5993"
+                },
+                {
+                  "alg": "SHA3-256",
+                  "content": "cb9798a3a5fdf0b1c3233f60f16e9f9ee74e4d451318fb905221ee652828dfff"
+                },
+                {
+                  "alg": "SHA3-512",
+                  "content": "e3f2ef307447c7e5cb994da1ca5c3ca390971a7d6062dbdf11f53cf28fe65eb5e1df31ec38474ab4e0feb2dddbc4b519a4984e5509212b5d79906eaaebed3f78"
+                }
+              ],
+              "licenses": [
+                {
+                  "license": {
+                    "id": "Apache-2.0"
+                  }
+                }
+              ],
+              "name": "spring-cloud-netflix-core",
+              "publisher": "Pivotal Software, Inc.",
+              "purl": "pkg:maven/org.springframework.cloud/spring-cloud-netflix-core@2.0.0.RELEASE?type=jar",
+              "scope": "required",
+              "type": "framework",
+              "version": "2.0.0.RELEASE"
+            },
+            {
+              "bom-ref": "pkg:maven/org.springframework.cloud/spring-cloud-netflix-eureka-client@2.0.0.RELEASE?type=jar",
+              "description": "Spring Cloud Netflix Eureka Client",
+              "evidence": {
+                "identity": {
+                  "confidence": 0.8,
+                  "field": "purl",
+                  "methods": [
+                    {
+                      "confidence": 0.8,
+                      "technique": "binary-analysis",
+                      "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\org\\springframework\\cloud\\spring-cloud-netflix-eureka-client\\2.0.0.RELEASE\\spring-cloud-netflix-eureka-client-2.0.0.RELEASE.jar"
+                    }
+                  ]
+                }
+              },
+              "group": "org.springframework.cloud",
+              "hashes": [
+                {
+                  "alg": "MD5",
+                  "content": "8b93d4d30de32748b186aeacfa618f67"
+                },
+                {
+                  "alg": "SHA-1",
+                  "content": "e00b09813d5d3714dbbc150b91553267124e2250"
+                },
+                {
+                  "alg": "SHA-256",
+                  "content": "7ff7145adc938be815a8055af0cdea0f720c6b356b57ac2136e53bcd5d25e97f"
+                },
+                {
+                  "alg": "SHA-512",
+                  "content": "8a3f0018f3bdc5bb1ad4e246526cbdb422202d2b699c3a0cac0a765dd1d865f87b778a702f96ff2ad7b8ac6197afa46b6a6555c694ad57e0d3ce8608d071da73"
+                },
+                {
+                  "alg": "SHA-384",
+                  "content": "dd690fb96277a00f46f6f81f53204d831853065abfc1bd57e61872b2c4c6858d26cd4be36d88cda8bd05e6e162c14299"
+                },
+                {
+                  "alg": "SHA3-384",
+                  "content": "237201a38459c81ecedba61d4d59a522cbea01b65297c1f068e11294dbc9da626035815b1846f08c1737058e33f021e9"
+                },
+                {
+                  "alg": "SHA3-256",
+                  "content": "cad94fdc93582973a4376fd3c4ee59ee34855af8f125db916de6e9b1a4b47793"
+                },
+                {
+                  "alg": "SHA3-512",
+                  "content": "fcca16621c429111e17349f412e5f630df3aaed591e8c67457902512f293dbd890c40bd481660e1f95ab4ee3674450e37bf1291afad0e7d8f540c61c267217b4"
+                }
+              ],
+              "licenses": [
+                {
+                  "license": {
+                    "id": "Apache-2.0"
+                  }
+                }
+              ],
+              "name": "spring-cloud-netflix-eureka-client",
+              "publisher": "Pivotal Software, Inc.",
+              "purl": "pkg:maven/org.springframework.cloud/spring-cloud-netflix-eureka-client@2.0.0.RELEASE?type=jar",
+              "scope": "required",
+              "type": "framework",
+              "version": "2.0.0.RELEASE"
+            },
+            {
+              "bom-ref": "pkg:maven/org.springframework.cloud/spring-cloud-starter-netflix-eureka-client@2.0.0.RELEASE?type=jar",
+              "description": "Spring Cloud Starter Netflix Eureka Client",
+              "evidence": {
+                "identity": {
+                  "confidence": 0.8,
+                  "field": "purl",
+                  "methods": [
+                    {
+                      "confidence": 0.8,
+                      "technique": "binary-analysis",
+                      "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\org\\springframework\\cloud\\spring-cloud-starter-netflix-eureka-client\\2.0.0.RELEASE\\spring-cloud-starter-netflix-eureka-client-2.0.0.RELEASE.jar"
+                    }
+                  ]
+                }
+              },
+              "group": "org.springframework.cloud",
+              "hashes": [
+                {
+                  "alg": "MD5",
+                  "content": "46d482bf052f34fc1fde298864af2215"
+                },
+                {
+                  "alg": "SHA-1",
+                  "content": "4e241e6685a4dfc45987945df6c2477503ae20d7"
+                },
+                {
+                  "alg": "SHA-256",
+                  "content": "4686ea441f3b924e7f1631d49a6fb89a771a778fc7fd32612163d3c60ec21d14"
+                },
+                {
+                  "alg": "SHA-512",
+                  "content": "2e512df35dff02c0814d1a59a7ba7dbf8a4280c1658565c115f5a599f80401df9d5da043b3c0868230b79ba7c04ec53138f98aeede29fd703ae2ea25d7f357b4"
+                },
+                {
+                  "alg": "SHA-384",
+                  "content": "fe253756cdd8724e26477c505988966012a1e103b07e2f404967ed6760f0cb934d288c5aef8883f462e19a2fe9ea9841"
+                },
+                {
+                  "alg": "SHA3-384",
+                  "content": "3a5cd5b3839f0fc79088457664f01597a6f948aa76efda13886f9144fa826b801ecf9b4d2b8135dd2d7d139fb985cacc"
+                },
+                {
+                  "alg": "SHA3-256",
+                  "content": "2d792b6b575950436fe620ac173535a7fa0b7deccf290cbeb37ae7a21b6f6416"
+                },
+                {
+                  "alg": "SHA3-512",
+                  "content": "3aa2f65011ba5f3923f0925d1b85180528ab5c57293353b3022ed8e3f90798a77cf13eae4beaea7d54eb60049a4776f5d9c994d56727c8bd7f8e4b9b39aa9d98"
+                }
+              ],
+              "licenses": [
+                {
+                  "license": {
+                    "id": "Apache-2.0"
+                  }
+                }
+              ],
+              "name": "spring-cloud-starter-netflix-eureka-client",
+              "publisher": "Pivotal Software, Inc.",
+              "purl": "pkg:maven/org.springframework.cloud/spring-cloud-starter-netflix-eureka-client@2.0.0.RELEASE?type=jar",
+              "scope": "required",
+              "type": "framework",
+              "version": "2.0.0.RELEASE"
+            },
+            {
+              "bom-ref": "pkg:maven/org.springframework/spring-web@5.0.7.RELEASE?type=jar",
+              "description": "Spring Web",
+              "evidence": {
+                "identity": {
+                  "confidence": 0.8,
+                  "field": "purl",
+                  "methods": [
+                    {
+                      "confidence": 0.8,
+                      "technique": "binary-analysis",
+                      "value": "C:\\Users\\user\\AppData\\Local\\Temp\\mvn-deps-NPbV0h\\org\\springframework\\spring-web\\5.0.7.RELEASE\\spring-web-5.0.7.RELEASE.jar"
+                    }
+                  ]
+                },
+                "occurrences": [
+                  {
+                    "location": "account-service\\src\\main\\java\\com\\piggymetrics\\account\\client\\AuthServiceClient.java#12"
+                  },
+                  {
+                    "location": "account-service\\src\\main\\java\\com\\piggymetrics\\account\\client\\StatisticsServiceClient.java#13"
+                  },
+                  {
+                    "location": "account-service\\src\\main\\java\\com\\piggymetrics\\account\\controller\\AccountController.java#13"
+                  },
+                  {
+                    "location": "account-service\\src\\main\\java\\com\\piggymetrics\\account\\controller\\AccountController.java#20"
+                  },
+                  {
+                    "location": "account-service\\src\\main\\java\\com\\piggymetrics\\account\\controller\\AccountController.java#25"
+                  },
+                  {
+                    "location": "account-service\\src\\main\\java\\com\\piggymetrics\\account\\controller\\AccountController.java#30"
+                  },
+                  {
+                    "location": "account-service\\src\\main\\java\\com\\piggymetrics\\account\\controller\\AccountController.java#35"
+                  },
+                  {
+                    "location": "account-service\\src\\main\\java\\com\\piggymetrics\\account\\controller\\ErrorHandler.java#10"
+                  },
+                  {
+                    "location": "account-service\\src\\main\\java\\com\\piggymetrics\\account\\controller\\ErrorHandler.java#17"
+                  },
+                  {
+                    "location": "account-service\\src\\main\\java\\com\\piggymetrics\\account\\controller\\ErrorHandler.java#18"
+                  },
+                  {
+                    "location": "account-service\\src\\main\\java\\com\\piggymetrics\\account\\service\\security\\CustomUserInfoTokenServices.java#129"
+                  },
+                  {
+                    "location": "auth-service\\src\\main\\java\\com\\piggymetrics\\auth\\controller\\UserController.java#15"
+                  },
+                  {
+                    "location": "auth-service\\src\\main\\java\\com\\piggymetrics\\auth\\controller\\UserController.java#16"
+                  },
+                  {
+                    "location": "auth-service\\src\\main\\java\\com\\piggymetrics\\auth\\controller\\UserController.java#22"
+                  },
+                  {
+                    "location": "auth-service\\src\\main\\java\\com\\piggymetrics\\auth\\controller\\UserController.java#28"
+                  },
+                  {
+                    "location": "notification-service\\src\\main\\java\\com\\piggymetrics\\notification\\client\\AccountServiceClient.java#12"
+                  },
+                  {
+                    "location": "notification-service\\src\\main\\java\\com\\piggymetrics\\notification\\controller\\RecipientController.java#14"
+                  },
+                  {
+                    "location": "notification-service\\src\\main\\java\\com\\piggymetrics\\notification\\controller\\RecipientController.java#15"
+                  },
+                  {
+                    "location": "notification-service\\src\\main\\java\\com\\piggymetrics\\notification\\controller\\RecipientController.java#21"
+                  },
+                  {
+                    "location": "notification-service\\src\\main\\java\\com\\piggymetrics\\notification\\controller\\RecipientController.java#26"
+                  },
+                  {
+                    "location": "statistics-service\\src\\main\\java\\com\\piggymetrics\\statistics\\client\\ExchangeRatesClient.java#13"
+                  },
+                  {
+                    "location": "statistics-service\\src\\main\\java\\com\\piggymetrics\\statistics\\controller\\StatisticsController.java#14"
+                  },
+                  {
+                    "location": "statistics-service\\src\\main\\java\\com\\piggymetrics\\statistics\\controller\\StatisticsController.java#20"
+                  },
+                  {
+                    "location": "statistics-service\\src\\main\\java\\com\\piggymetrics\\statistics\\controller\\StatisticsController.java#26"
+                  },
+                  {
+                    "location": "statistics-service\\src\\main\\java\\com\\piggymetrics\\statistics\\controller\\StatisticsController.java#32"
+                  }
+                ]
+              },
+              "group": "org.springframework",
+              "hashes": [
+                {
+                  "alg": "MD5",
+                  "content": "cdb97ca6e419ea429244db6b01ea9d09"
+                },
+                {
+                  "alg": "SHA-1",
+                  "content": "2e04c6c2922fbfa06b5948be14a5782db168b6ec"
+                },
+                {
+                  "alg": "SHA-256",
+                  "content": "d100479905e911a3201de66566f59bd5e2d4137f9d95b6d314acbb80ae985d22"
+                },
+                {
+                  "alg": "SHA-512",
+                  "content": "da438577b4aeb0722ecfcaccfc43a37a07c78fdd6badc87caceb3abe58f31f82df9199e26a6b889a24bfe30cdf47626fbe8c4eb68e0f49497bd4b34e99f88b66"
+                },
+                {
+                  "alg": "SHA-384",
+                  "content": "8af38fbf471db8437161cca583b115bad2084544661de14b98f023013eac4a735e7f820bdaf72118e55b5cbaf78cf1da"
+                },
+                {
+                  "alg": "SHA3-384",
+                  "content": "797a7bd86ef730de5377d6fc66c1b7d03188260b62fbb72a58fbc025926877bbc94b5a7c7a03e4f4e1c0b12fe9a3df13"
+                },
+                {
+                  "alg": "SHA3-256",
+                  "content": "f86905c962d81e77ccdfeb4e189aad1cd22d015f7b35cb676a940e39aeb7c284"
+                },
+                {
+                  "alg": "SHA3-512",
+                  "content": "e15fe01672fed6048e69d14ff865ce2986343d339c4ed806e5de0a2038b01a25dbbf457d3aa399692e8d8ad834c03e84619f683cd5bfee03facbf4500fbc51bb"
+                }
+              ],
+              "licenses": [
+                {
+                  "license": {
+                    "id": "Apache-2.0"
+                  }
+                }
+              ],
+              "name": "spring-web",
+              "publisher": "Spring IO",
+              "purl": "pkg:maven/org.springframework/spring-web@5.0.7.RELEASE?type=jar",
+              "scope": "required",
+              "type": "framework",
+              "version": "5.0.7.RELEASE"
+            }
+          ],
+          "applications": [],
+          "other_types": []
+        },
+        "misc_data": {},
+        "services": [
+          {
+            "authenticated": true,
+            "endpoints": [
+              "/{name}"
+            ],
+            "name": "com-piggymetrics-account-controller-AccountController-getAccountByName-service",
+            "x-trust-boundary": true
+          },
+          {
+            "endpoints": [
+              "/current"
+            ],
+            "name": "com-piggymetrics-account-controller-AccountController-getCurrentAccount-service"
+          },
+          {
+            "endpoints": [
+              "/current"
+            ],
+            "name": "com-piggymetrics-account-controller-AccountController-saveCurrentAccount-service"
+          },
+          {
+            "endpoints": [
+              "/current"
+            ],
+            "name": "com-piggymetrics-auth-controller-UserController-getUser-service"
+          },
+          {
+            "endpoints": [
+              "/accounts/{accountName}"
+            ],
+            "name": "com-piggymetrics-notification-client-AccountServiceClient-getAccount-service"
+          },
+          {
+            "endpoints": [
+              "/current"
+            ],
+            "name": "com-piggymetrics-notification-controller-RecipientController-getCurrentNotificationsSettings-service"
+          },
+          {
+            "endpoints": [
+              "/current"
+            ],
+            "name": "com-piggymetrics-notification-controller-RecipientController-saveCurrentNotificationsSettings-service"
+          },
+          {
+            "endpoints": [
+              "/latest"
+            ],
+            "name": "com-piggymetrics-statistics-client-ExchangeRatesClient-getRates-service"
+          }
+        ],
+        "dependencies": [
+          {
+            "ref": "pkg:maven/ch.qos.logback/logback-classic@1.2.3?type=jar",
+            "dependsOn": [
+              "pkg:maven/ch.qos.logback/logback-core@1.2.3?type=jar",
+              "pkg:maven/org.slf4j/slf4j-api@1.7.25?type=jar"
+            ]
+          },
+          {
+            "ref": "pkg:maven/ch.qos.logback/logback-core@1.2.3?type=jar",
+            "dependsOn": []
+          },
+          {
+            "ref": "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.10.0?type=jar",
+            "dependsOn": [
+              "pkg:maven/org.apache.logging.log4j/log4j-api@2.10.0?type=jar",
+              "pkg:maven/org.slf4j/slf4j-api@1.7.25?type=jar"
+            ]
+          },
+          {
+            "ref": "pkg:maven/org.slf4j/slf4j-api@1.7.25?type=jar",
+            "dependsOn": []
+          },
+          {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-autoconfigure@2.0.3.RELEASE?type=jar",
+            "dependsOn": [
+              "pkg:maven/org.springframework.boot/spring-boot@2.0.3.RELEASE?type=jar"
+            ]
+          },
+          {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot-starter-logging@2.0.3.RELEASE?type=jar",
+            "dependsOn": [
+              "pkg:maven/ch.qos.logback/logback-classic@1.2.3?type=jar",
+              "pkg:maven/org.apache.logging.log4j/log4j-to-slf4j@2.10.0?type=jar",
+              "pkg:maven/org.slf4j/jul-to-slf4j@1.7.25?type=jar"
+            ]
+          },
+          {
+            "ref": "pkg:maven/org.springframework.boot/spring-boot@2.0.3.RELEASE?type=jar",
+            "dependsOn": [
+              "pkg:maven/org.springframework/spring-context@5.0.7.RELEASE?type=jar",
+              "pkg:maven/org.springframework/spring-core@5.0.7.RELEASE?type=jar"
+            ]
+          },
+          {
+            "ref": "pkg:maven/org.springframework/spring-aop@5.0.7.RELEASE?type=jar",
+            "dependsOn": [
+              "pkg:maven/org.springframework/spring-beans@5.0.7.RELEASE?type=jar",
+              "pkg:maven/org.springframework/spring-core@5.0.7.RELEASE?type=jar"
+            ]
+          },
+          {
+            "ref": "pkg:maven/org.springframework/spring-beans@5.0.7.RELEASE?type=jar",
+            "dependsOn": [
+              "pkg:maven/org.springframework/spring-core@5.0.7.RELEASE?type=jar"
+            ]
+          },
+          {
+            "ref": "pkg:maven/org.springframework/spring-context@5.0.7.RELEASE?type=jar",
+            "dependsOn": [
+              "pkg:maven/org.springframework/spring-aop@5.0.7.RELEASE?type=jar",
+              "pkg:maven/org.springframework/spring-beans@5.0.7.RELEASE?type=jar",
+              "pkg:maven/org.springframework/spring-core@5.0.7.RELEASE?type=jar",
+              "pkg:maven/org.springframework/spring-expression@5.0.7.RELEASE?type=jar"
+            ]
+          },
+          {
+            "ref": "pkg:maven/org.springframework/spring-core@5.0.7.RELEASE?type=jar",
+            "dependsOn": [
+              "pkg:maven/org.springframework/spring-jcl@5.0.7.RELEASE?type=jar"
+            ]
+          },
+          {
+            "ref": "pkg:maven/org.springframework/spring-expression@5.0.7.RELEASE?type=jar",
+            "dependsOn": [
+              "pkg:maven/org.springframework/spring-core@5.0.7.RELEASE?type=jar"
+            ]
+          },
+          {
+            "ref": "pkg:maven/org.springframework/spring-jcl@5.0.7.RELEASE?type=jar",
+            "dependsOn": []
+          }
+        ]
+      }
+    }
+  },
+  "result_5": {
+    "common_summary": {
+      "misc_data": {}
+    },
+    "diff_summary": {
+      "bom_2.json": {
+        "components": {
+          "libraries": [
+            {
+              "bom-ref": "pkg:pypi/requests@2.32.3",
+              "evidence": {
+                "identity": {
+                  "confidence": 0.8,
+                  "field": "purl",
+                  "methods": [
+                    {
+                      "confidence": 0.8,
+                      "technique": "manifest-analysis",
+                      "value": "/home/runner/work/src_repos/python/django-goat/requirements_tests.txt"
+                    }
+                  ]
+                }
+              },
+              "group": "",
+              "name": "requests",
+              "properties": [
+                {
+                  "name": "SrcFile",
+                  "value": "/home/runner/work/src_repos/python/django-goat/requirements_tests.txt"
+                }
+              ],
+              "purl": "pkg:pypi/requests@2.32.3",
+              "type": "library",
+              "version": "2.32.3"
+            }
+          ],
+          "frameworks": [],
+          "applications": [],
+          "other_types": []
+        },
+        "misc_data": {}
+      },
+      "bom_1.json": {
+        "components": {
+          "libraries": [
+            {
+              "bom-ref": "pkg:pypi/requests@2.31.0",
+              "evidence": {
+                "identity": {
+                  "confidence": 0.8,
+                  "field": "purl",
+                  "methods": [
+                    {
+                      "confidence": 0.8,
+                      "technique": "manifest-analysis",
+                      "value": "/home/runner/work/src_repos/python/django-goat/requirements_tests.txt"
+                    }
+                  ]
+                }
+              },
+              "group": "",
+              "name": "requests",
+              "properties": [
+                {
+                  "name": "SrcFile",
+                  "value": "/home/runner/work/src_repos/python/django-goat/requirements_tests.txt"
+                }
+              ],
+              "purl": "pkg:pypi/requests@2.31.0",
+              "type": "library",
+              "version": "2.31.0"
+            }
+          ],
+          "frameworks": [],
+          "applications": [],
+          "other_types": []
+        },
+        "misc_data": {}
+      }
+    }
+  },
+  "result_6": {
+    "test/sbom-python.json": {
+      "components": [
+        {
+          "version": "2.11.3"
+        },
+        {
+          "bom-ref": "pkg:pypi/markupsafe@1.1.1",
+          "name": "MarkupSafe",
+          "purl": "pkg:pypi/markupsafe@1.1.1",
+          "version": "1.1.1"
+        },
+        {
+          "version": "1.0.1"
+        },
+        {
+          "bom-ref": "pkg:pypi/click@7.1.2",
+          "name": "click",
+          "purl": "pkg:pypi/click@7.1.2",
+          "version": "7.1.2"
+        },
+        {
+          "bom-ref": "pkg:pypi/itsdangerous@1.1.0",
+          "name": "itsdangerous",
+          "purl": "pkg:pypi/itsdangerous@1.1.0",
+          "version": "1.1.0"
+        }
+      ],
+      "dependencies": [
+        {
+          "ref": "pkg:pypi/click@7.1.2"
+        },
+        {
+          "dependsOn": [
+            "pkg:pypi/click@7.1.2",
+            "pkg:pypi/itsdangerous@1.1.0",
+            "pkg:pypi/jinja2@2.11.3",
+            "pkg:pypi/werkzeug@1.0.1"
+          ],
+          "ref": "pkg:pypi/flask@1.1.2"
+        },
+        {
+          "ref": "pkg:pypi/itsdangerous@1.1.0"
+        }
+      ],
+      "services": [
+        {
+          "endpoints": [
+            "/create_user"
+          ],
+          "name": "users-service"
+        }
+      ]
+    },
+    "test/sbom-python2.json": {
+      "components": [
+        {
+          "version": "2.10.2"
+        },
+        {
+          "version": "1.5.1"
+        }
+      ]
+    }
+  },
+  "result_7": {
+    "bomFormat": "CycloneDX",
+    "components": [
+      {
+        "bom-ref": "pkg:pypi/jinja2@2.11.3",
+        "group": "",
+        "name": "Jinja2",
+        "purl": "pkg:pypi/jinja2@2.11.3",
+        "type": "library"
+      },
+      {
+        "group": "",
+        "type": "library"
+      },
+      {
+        "bom-ref": "pkg:pypi/werkzeug@1.0.1",
+        "group": "",
+        "name": "Werkzeug",
+        "purl": "pkg:pypi/werkzeug@1.0.1",
+        "type": "library"
+      },
+      {
+        "bom-ref": "pkg:github/actions/checkout@v2",
+        "group": "actions",
+        "name": "checkout",
+        "purl": "pkg:github/actions/checkout@v2",
+        "type": "application",
+        "version": "v2"
+      },
+      {
+        "group": "",
+        "type": "library"
+      },
+      {
+        "bom-ref": "pkg:pypi/flask@1.1.2",
+        "group": "",
+        "name": "flask",
+        "purl": "pkg:pypi/flask@1.1.2",
+        "type": "framework",
+        "version": "1.1.2"
+      },
+      {
+        "group": "",
+        "type": "library"
+      },
+      {
+        "bom-ref": "pkg:github/actions/setup-python@v2",
+        "group": "actions",
+        "name": "setup-python",
+        "purl": "pkg:github/actions/setup-python@v2",
+        "type": "application",
+        "version": "v2"
+      }
+    ],
+    "dependencies": [
+      {
+        "dependsOn": []
+      },
+      {
+        "dependsOn": [
+          "pkg:pypi/flask@1.1.2"
+        ],
+        "ref": "pkg:pypi/flask-webgoat@latest"
+      },
+      {
+        "dependsOn": []
+      },
+      {
+        "dependsOn": [
+          "pkg:pypi/markupsafe@1.1.1"
+        ],
+        "ref": "pkg:pypi/jinja2@2.11.3"
+      },
+      {
+        "dependsOn": [],
+        "ref": "pkg:pypi/markupsafe@1.1.1"
+      },
+      {
+        "dependsOn": [],
+        "ref": "pkg:pypi/werkzeug@1.0.1"
+      }
+    ],
+    "metadata": {
+      "authors": [
+        {
+          "name": "OWASP Foundation"
+        }
+      ],
+      "component": {
+        "bom-ref": "pkg:gem/flask-webgoat@latest",
+        "group": "",
+        "name": "flask-webgoat",
+        "purl": "pkg:gem/flask-webgoat@latest",
+        "type": "application",
+        "version": "latest"
+      },
+      "lifecycles": [
+        {
+          "phase": "build"
+        }
+      ],
+      "tools": {
+        "components": [
+          {
+            "author": "OWASP Foundation",
+            "group": "@cyclonedx",
+            "name": "cdxgen",
+            "publisher": "OWASP Foundation",
+            "type": "application"
+          }
+        ]
+      }
+    },
+    "services": [
+      {
+        "authenticated": false,
+        "endpoints": [
+          "/message",
+          "/grep_processes"
+        ],
+        "name": "actions-service"
+      },
+      {
+        "authenticated": false,
+        "endpoints": [
+          "/login",
+          "/login_and_redirect"
+        ],
+        "name": "auth-service"
+      },
+      {
+        "authenticated": false,
+        "endpoints": [
+          "/status",
+          "/ping"
+        ],
+        "name": "status-service"
+      },
+      {
+        "authenticated": false,
+        "endpoints": [
+          "/search"
+        ],
+        "name": "ui-service"
+      },
+      {
+        "authenticated": false
+      }
+    ],
+    "specVersion": "1.5",
+    "version": 2
+  },
+  "result_8": {
+    "components": [
+      {
+        "version": "2.11.3"
+      },
+      {
+        "bom-ref": "pkg:pypi/markupsafe@1.1.1",
+        "name": "MarkupSafe",
+        "purl": "pkg:pypi/markupsafe@1.1.1",
+        "version": "1.1.1"
+      },
+      {
+        "version": "1.0.1"
+      },
+      {
+        "bom-ref": "pkg:pypi/click@7.1.2",
+        "name": "click",
+        "purl": "pkg:pypi/click@7.1.2",
+        "version": "7.1.2"
+      },
+      {
+        "bom-ref": "pkg:pypi/itsdangerous@1.1.0",
+        "name": "itsdangerous",
+        "purl": "pkg:pypi/itsdangerous@1.1.0",
+        "version": "1.1.0"
+      }
+    ],
+    "dependencies": [
+      {
+        "ref": "pkg:pypi/click@7.1.2"
+      },
+      {
+        "dependsOn": [
+          "pkg:pypi/click@7.1.2",
+          "pkg:pypi/itsdangerous@1.1.0",
+          "pkg:pypi/jinja2@2.11.3",
+          "pkg:pypi/werkzeug@1.0.1"
+        ],
+        "ref": "pkg:pypi/flask@1.1.2"
+      },
+      {
+        "ref": "pkg:pypi/itsdangerous@1.1.0"
+      }
+    ],
+    "services": [
+      {
+        "endpoints": [
+          "/create_user"
+        ],
+        "name": "users-service"
+      }
+    ]
+  },
+  "result_9": {
+    "components": [
+      {
+        "version": "2.10.2"
+      },
+      {
+        "version": "1.5.1"
+      }
+    ]
+  },
+  "result_12": {
+    "bomFormat": "CycloneDX",
+    "components": [
+      {
+        "bom-ref": "pkg:pypi/jinja2@2.11.3",
+        "group": "",
+        "name": "Jinja2",
+        "purl": "pkg:pypi/jinja2@2.11.3",
+        "type": "library"
+      },
+      {
+        "group": "",
+        "type": "library"
+      },
+      {
+        "bom-ref": "pkg:pypi/werkzeug@1.0.1",
+        "group": "",
+        "name": "Werkzeug",
+        "purl": "pkg:pypi/werkzeug@1.0.1",
+        "type": "library"
+      },
+      {
+        "bom-ref": "pkg:github/actions/checkout@v2",
+        "group": "actions",
+        "name": "checkout",
+        "purl": "pkg:github/actions/checkout@v2",
+        "type": "application",
+        "version": "v2"
+      },
+      {
+        "group": "",
+        "type": "library"
+      },
+      {
+        "bom-ref": "pkg:pypi/flask@1.1.2",
+        "group": "",
+        "name": "flask",
+        "purl": "pkg:pypi/flask@1.1.2",
+        "type": "framework",
+        "version": "1.1.2"
+      },
+      {
+        "group": "",
+        "type": "library"
+      },
+      {
+        "bom-ref": "pkg:github/actions/setup-python@v2",
+        "group": "actions",
+        "name": "setup-python",
+        "purl": "pkg:github/actions/setup-python@v2",
+        "type": "application",
+        "version": "v2"
+      }
+    ],
+    "dependencies": [
+      {
+        "dependsOn": []
+      },
+      {
+        "dependsOn": [
+          "pkg:pypi/flask@1.1.2"
+        ],
+        "ref": "pkg:pypi/flask-webgoat@latest"
+      },
+      {
+        "dependsOn": []
+      },
+      {
+        "dependsOn": [
+          "pkg:pypi/markupsafe@1.1.1"
+        ],
+        "ref": "pkg:pypi/jinja2@2.11.3"
+      },
+      {
+        "dependsOn": [],
+        "ref": "pkg:pypi/markupsafe@1.1.1"
+      },
+      {
+        "dependsOn": [],
+        "ref": "pkg:pypi/werkzeug@1.0.1"
+      }
+    ],
+    "metadata": {
+      "authors": [
+        {
+          "name": "OWASP Foundation"
+        }
+      ],
+      "component": {
+        "bom-ref": "pkg:gem/flask-webgoat@latest",
+        "group": "",
+        "name": "flask-webgoat",
+        "purl": "pkg:gem/flask-webgoat@latest",
+        "type": "application",
+        "version": "latest"
+      },
+      "lifecycles": [
+        {
+          "phase": "build"
+        }
+      ],
+      "tools": {
+        "components": [
+          {
+            "author": "OWASP Foundation",
+            "group": "@cyclonedx",
+            "name": "cdxgen",
+            "publisher": "OWASP Foundation",
+            "type": "application"
+          }
+        ]
+      }
+    },
+    "services": [
+      {
+        "authenticated": false,
+        "endpoints": [
+          "/message",
+          "/grep_processes"
+        ],
+        "name": "actions-service"
+      },
+      {
+        "authenticated": false,
+        "endpoints": [
+          "/login",
+          "/login_and_redirect"
+        ],
+        "name": "auth-service"
+      },
+      {
+        "authenticated": false,
+        "endpoints": [
+          "/status",
+          "/ping"
+        ],
+        "name": "status-service"
+      },
+      {
+        "authenticated": false,
+        "endpoints": [
+          "/search"
+        ],
+        "name": "ui-service"
+      },
+      {
+        "authenticated": false
+      }
+    ],
+    "specVersion": "1.5",
+    "version": 2
+  }
+}


### PR DESCRIPTION
# Changes
- Fixes bug related to unintended options persistence.
- Restores -x/--exclude option so that it can be used with bom-diff
- Adds externalReferences to default excludes