### PR TITLE
Feat: Compare component property/license/hash lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,9 @@ is attributable to an updated version. Dependency refs and dependents are compar
 string removed rather than checking for a newer version.
 
 The --allow-new-data option allows for empty fields in the original BOM not to be reported as a 
-difference when the data is populated in the second specified BOM. This option only applies to the 
-fields included by default.
+difference when the data is populated in the second specified BOM. It also addresses when a field 
+such as properties is expanded, checking that all original elements are still present but allowing
+additional elements in the newer BOM.
 
 The --components-only option only analyzes components, not services, dependencies, or other data.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "custom-json-diff"
-version = "1.3.0"
+version = "1.4.0"
 description = "Custom JSON and CycloneDx BOM diffing and comparison tool."
 authors = [
   { name = "Caroline Russell", email = "caroline@appthreat.dev" },

--- a/test/test_bom_diff.py
+++ b/test/test_bom_diff.py
@@ -237,6 +237,74 @@ def bom_dicts_8():
 
 
 @pytest.fixture
+def bom_component_9():
+    return BomComponent(
+        {
+          "bom-ref": "pkg:maven/io.netty/netty-resolver-dns@4.1.110.Final-SNAPSHOT?type=jar",
+          "group": "io.netty",
+          "name": "netty-resolver-dns",
+          "properties": [
+            {
+              "name": "SrcFile",
+              "value": "/home/runner/work/src_repos/java/netty/pom.xml"
+            },
+            {
+              "name": "SrcFile",
+              "value": "/home/runner/work/src_repos/java/netty/resolver-dns-native-macos/pom.xml"
+            },
+            {
+              "name": "SrcFile",
+              "value": "/home/runner/work/src_repos/java/netty/resolver-dns-classes-macos/pom.xml"
+            },
+          ],
+          "publisher": "The Netty Project",
+          "purl": "pkg:maven/io.netty/netty-resolver-dns@4.1.110.Final-SNAPSHOT?type=jar",
+          "scope": "required",
+          "type": "framework",
+          "version": "4.1.110.Final-SNAPSHOT"
+        }, Options(file_1="bom_1.json", file_2="bom_2.json", bom_diff=True, allow_new_data=True, bom_num=1)
+    )
+
+
+@pytest.fixture
+def bom_component_10():
+    return BomComponent(
+        {
+          "bom-ref": "pkg:maven/io.netty/netty-resolver-dns@4.1.110.Final-SNAPSHOT?type=jar",
+          "group": "io.netty",
+          "name": "netty-resolver-dns",
+          "properties": [
+            {
+              "name": "SrcFile",
+              "value": "/home/runner/work/src_repos/java/netty/pom.xml"
+            },
+            {
+              "name": "SrcFile",
+              "value": "/home/runner/work/src_repos/java/netty/resolver-dns-native-macos/pom.xml"
+            },
+            {
+              "name": "SrcFile",
+              "value": "/home/runner/work/src_repos/java/netty/resolver-dns-classes-macos/pom.xml"
+            },
+            {
+              "name": "SrcFile",
+              "value": "/home/runner/work/src_repos/java/netty/handler-ssl-ocsp/pom.xml"
+            },
+            {
+              "name": "SrcFile",
+              "value": "/home/runner/work/src_repos/java/netty/all/pom.xml"
+            }
+          ],
+          "publisher": "The Netty Project",
+          "purl": "pkg:maven/io.netty/netty-resolver-dns@4.1.110.Final-SNAPSHOT?type=jar",
+          "scope": "required",
+          "type": "framework",
+          "version": "4.1.110.Final-SNAPSHOT"
+        }, Options(file_1="bom_1.json", file_2="bom_2.json", bom_diff=True, allow_new_data=True, bom_num=2)
+    )
+
+
+@pytest.fixture
 def results():
     with open("test/test_data.json", "r", encoding="utf-8") as f:
         return json.load(f)
@@ -264,3 +332,10 @@ def test_bom_diff_options(results, bom_dicts_1, bom_dicts_2, bom_dicts_3, bom_di
     result_summary = perform_bom_diff(bom_dicts_5, bom_dicts_6)
     assert result_summary == results["result_3"]
 
+
+def test_bom_components_lists(bom_component_9, bom_component_10):
+    # tests allow_new_data with component lists of dicts
+    assert bom_component_9 == bom_component_10
+    bom_component_9.options.bom_num = 2
+    bom_component_10.options.bom_num = 1
+    assert bom_component_9 != bom_component_10


### PR DESCRIPTION
# Changes
- Allows the --allow-new-data option to apply to the fields that are lists of dicts as it does other component properties