### PR TITLE
Feat: Add --bom-profile argument for limited comparison.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ options:
 
 preset-diff usage
 ```
-usage: custom-json-diff preset-diff [-h] [--allow-new-versions] [--allow-new-data] [--type PRESET_TYPE] [-r REPORT_TEMPLATE] [--include-extra INCLUDE]
+usage: custom-json-diff preset-diff [-h] [--allow-new-versions] [--allow-new-data] [--type PRESET_TYPE] [-r REPORT_TEMPLATE] [--include-extra INCLUDE] [--include-empty] [--bom-profile BOM_PROFILE]
 
 options:
   -h, --help            show this help message and exit
@@ -50,6 +50,9 @@ options:
                         Jinja2 template to use for report generation.
   --include-extra INCLUDE
                         BOM only - include properties/evidence/licenses/hashes/externalReferences (list which with comma, no space, inbetween).
+  --include-empty, -e   Include keys with empty values in summary.
+  --bom-profile BOM_PROFILE, -b BOM_PROFILE
+                        Beta feature. Options: gn, gnv, nv -> only compare bom group/name/version. 
 
 ```
 ## Preset Diffs

--- a/custom_json_diff/cli.py
+++ b/custom_json_diff/cli.py
@@ -52,9 +52,9 @@ def build_args() -> argparse.Namespace:
         dest="config"
     )
     subparsers = parser.add_subparsers(help="subcommand help")
-    parser_pc_diff = subparsers.add_parser("preset-diff", help="Compare CycloneDX BOMs or Oasis CSAFs")
-    parser_pc_diff.set_defaults(preset_type="")
-    parser_pc_diff.add_argument(
+    parser_ps_diff = subparsers.add_parser("preset-diff", help="Compare CycloneDX BOMs or Oasis CSAFs")
+    parser_ps_diff.set_defaults(preset_type="")
+    parser_ps_diff.add_argument(
         "--allow-new-versions",
         "-anv",
         action="store_true",
@@ -62,7 +62,7 @@ def build_args() -> argparse.Namespace:
         dest="allow_new_versions",
         default=False,
     )
-    parser_pc_diff.add_argument(
+    parser_ps_diff.add_argument(
         "--allow-new-data",
         "-and",
         action="store_true",
@@ -70,13 +70,13 @@ def build_args() -> argparse.Namespace:
         dest="allow_new_data",
         default=False,
     )
-    parser_pc_diff.add_argument(
+    parser_ps_diff.add_argument(
         "--type",
         action="store",
         help="Either bom or csaf",
         dest="preset_type",
     )
-    parser_pc_diff.add_argument(
+    parser_ps_diff.add_argument(
         "-r",
         "--report-template",
         action="store",
@@ -84,19 +84,24 @@ def build_args() -> argparse.Namespace:
         dest="report_template",
         default="",
     )
-    parser_pc_diff.add_argument(
+    parser_ps_diff.add_argument(
         "--include-extra",
         action="store",
         help="BOM only - include properties/evidence/licenses/hashes/externalReferences (list which with comma, no space, inbetween).",
         dest="include",
     )
-    parser_pc_diff.add_argument(
+    parser_ps_diff.add_argument(
         "--include-empty",
         "-e",
         action="store_true",
         default=False,
         dest="include_empty",
         help="Include keys with empty values in summary.",
+    )
+    parser_ps_diff.add_argument(
+        "--bom-profile",
+        "-b",
+        help="Beta feature. Options: gn, gnv, nv -> only compare bom group/name/version."
     )
     parser.add_argument(
         "-x",
@@ -124,6 +129,8 @@ def main():
     preset_type = args.preset_type.lower()
     if preset_type and preset_type not in ("bom", "csaf"):
         raise ValueError("Preconfigured type must be either bom or csaf.")
+    if args.bom_profile and args.bom_profile not in ("gn", "gnv", "nv"):
+        raise ValueError("BOM profile must be either gn, gnv, or nv.")
     options = Options(
         allow_new_versions=args.allow_new_versions,
         allow_new_data=args.allow_new_data,

--- a/custom_json_diff/lib/custom_diff.py
+++ b/custom_json_diff/lib/custom_diff.py
@@ -71,8 +71,30 @@ def compare_dicts(options: "Options") -> Tuple[int, "BomDicts|CsafDicts|FlatDict
 
 
 def filter_dict(data: Dict, options: "Options") -> FlatDicts:
+    if options.bom_profile:
+        match options.bom_profile:
+            case "gnv":
+                data = filter_on_bom_profile(data, {"group", "name", "version"})
+            case "gn":
+                data = filter_on_bom_profile(data, {"group", "name"})
+            case "nv":
+                data = filter_on_bom_profile(data, {"name", "version"})
     data = flatten(sort_dict_lists(data, options.sort_keys))
     return FlatDicts(data).filter_out_keys(options.exclude)
+
+
+def filter_on_bom_profile(data: Dict, profile_fields: Set) -> Dict:
+    if not data.get("components"):
+        return data
+    new_components = []
+    for comp in data["components"]:
+        ncomp = {}
+        for key, value in comp.items():
+            if key in profile_fields:
+                ncomp[key] = value
+        new_components.append(ncomp)
+    data["components"] = new_components
+    return data
 
 
 def generate_counts(data: Dict) -> Dict:

--- a/custom_json_diff/lib/utils.py
+++ b/custom_json_diff/lib/utils.py
@@ -101,8 +101,10 @@ def export_html_report(outfile: str, diffs: Dict, options: "Options", status: in
                        stats_summary: Dict | None = None) -> None:
     if options.report_template:
         template_file = options.report_template
+    elif options.bom_profile:
+        template_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), "bom_diff_template_minimal.j2")
     else:
-        template_file = options.report_template or os.path.join(os.path.dirname(os.path.realpath(__file__)), f"{options.preconfig_type}_diff_template.j2")
+        template_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), f"{options.preconfig_type}_diff_template.j2")
     template = file_read(template_file)
     jinja_env = Environment(autoescape=True)
     jinja_tmpl = jinja_env.from_string(str(template))
@@ -112,7 +114,7 @@ def export_html_report(outfile: str, diffs: Dict, options: "Options", status: in
         else:
             report_result = render_csaf_template(diffs, jinja_tmpl, options, status)
     except TypeError:
-        logger.warning(f"Could not render html report for {options.file_1} and {options.file_2} BOM diff. Likely an expected key is missing.")
+        logger.warning(f"Could not render html report for {options.file_1} and {options.file_2} {options.preconfig_type} diff. Likely an expected key is missing.")
         return
     file_write(outfile, report_result, error_msg=f"Unable to generate HTML report at {outfile}.",
                success_msg=f"HTML report generated: {outfile}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "custom-json-diff"
-version = "2.1.2"
+version = "2.1.3"
 description = "CycloneDx BOM and Oasis CSAF diffing and comparison tool."
 authors = [
   { name = "Caroline Russell", email = "caroline@appthreat.dev" },

--- a/test/test_custom_json_diff.py
+++ b/test/test_custom_json_diff.py
@@ -3,7 +3,7 @@ import json
 import pytest
 
 from custom_json_diff.lib.custom_diff import (
-    compare_dicts, get_bom_status, get_diff, json_to_class
+    compare_dicts, filter_on_bom_profile, get_bom_status, get_diff, json_to_class
 )
 from custom_json_diff.lib.custom_diff_classes import Options
 
@@ -90,3 +90,18 @@ def test_get_bom_status():
     assert max(get_bom_status(diff_summary_1), get_bom_status(diff_summary_2)) == 2
     diff_summary_1["services"] = [{"name": "test"}]
     assert max(get_bom_status(diff_summary_1), get_bom_status(diff_summary_2)) == 3
+
+
+def test_filter_on_bom_profile():
+    data = {"components": [{"name": "component1", "version": "1.0", "group": "group1"},
+                           {"name": "component2", "version": "2.0"}]}
+    assert filter_on_bom_profile(data, {"name", "version"}) == {'components': [{'name': 'component1', 'version': '1.0'},
+                {'name': 'component2', 'version': '2.0'}]}
+    data = {"components": [{"name": "component1", "version": "1.0", "group": "group1"}]}
+    assert filter_on_bom_profile(data, {"name", "group"}) == {"components": [{"name": "component1", "group": "group1"}]}
+    assert filter_on_bom_profile({"components": []}, {"name"}) == {"components": []}
+    assert filter_on_bom_profile({}, {"name"}) == {}
+    assert filter_on_bom_profile( {"components": []}, {"name"}) == {"components": []}
+    data = {"metadata": {"author": "test"},
+        "components": [{"name": "component1", "version": "1.0"}]}
+    assert filter_on_bom_profile(data, {"name"}) == {"metadata": {"author": "test"}, "components": [{"name": "component1"}]}


### PR DESCRIPTION
# Changes
This PR adds the --bom-profile option to the preset-diff command.

```
usage: custom-json-diff preset-diff [-h] [--allow-new-versions] [--allow-new-data] [--type PRESET_TYPE] [-r REPORT_TEMPLATE] [--include-extra INCLUDE] [--include-empty] [--bom-profile BOM_PROFILE]

options:
  -h, --help            show this help message and exit
  --allow-new-versions, -anv
                        BOM only - allow newer versions in second BOM to pass.
  --allow-new-data, -and
                        Allow populated values in newer BOM or CSAF to pass against empty values in original BOM/CSAF.
  --type PRESET_TYPE    Either bom or csaf
  -r REPORT_TEMPLATE, --report-template REPORT_TEMPLATE
                        Jinja2 template to use for report generation.
  --include-extra INCLUDE
                        BOM only - include properties/evidence/licenses/hashes/externalReferences (list which with comma, no space, inbetween).
  --include-empty, -e   Include keys with empty values in summary.
  --bom-profile BOM_PROFILE, -b BOM_PROFILE
                        Beta feature. Options: gn, gnv, nv -> only compare bom group/name/version. 
```