### PR TITLE
Fix --bom-profile bugs.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include custom_json_diff/lib/bom_diff_template.j2
+include custom_json_diff/lib/bom_diff_template_minimal.j2
 include custom_json_diff/lib/csaf_diff_template.j2

--- a/custom_json_diff/cli.py
+++ b/custom_json_diff/cli.py
@@ -129,8 +129,9 @@ def main():
     preset_type = args.preset_type.lower()
     if preset_type and preset_type not in ("bom", "csaf"):
         raise ValueError("Preconfigured type must be either bom or csaf.")
-    if args.bom_profile and args.bom_profile not in ("gn", "gnv", "nv"):
-        raise ValueError("BOM profile must be either gn, gnv, or nv.")
+    if args.bom_profile:
+        if args.bom_profile not in ("gn", "gnv", "nv"):
+            raise ValueError("BOM profile must be either gn, gnv, or nv.")
     options = Options(
         allow_new_versions=args.allow_new_versions,
         allow_new_data=args.allow_new_data,
@@ -142,7 +143,8 @@ def main():
         file_2=args.input[1],
         output=args.output,
         report_template=args.report_template,
-        include_empty=args.include_empty
+        include_empty=args.include_empty,
+        bom_profile=args.bom_profile
     )
     result, j1, j2 = compare_dicts(options)
     if preset_type == "bom":

--- a/custom_json_diff/lib/bom_diff_template.j2
+++ b/custom_json_diff/lib/bom_diff_template.j2
@@ -869,7 +869,7 @@
                     {% if not misc_data_1 %}
                         <td></td>
                     {% endif %}
-                    {% if misc_data_1 %}
+                    {% if misc_data_2 %}
                         <td>{{ misc_data_2 }}</td>
                     {% endif %}
                     {% if not misc_data_2 %}

--- a/custom_json_diff/lib/bom_diff_template_minimal.j2
+++ b/custom_json_diff/lib/bom_diff_template_minimal.j2
@@ -1,0 +1,645 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>BOM Diff Summary</title>
+    <style>
+
+        .table_summary {
+            display: grid;
+            grid-template-columns: 5% 90% 5%;
+        }
+
+        .table_summary2 {
+            display: grid;
+            grid-template-columns: 10% 25% 4% 51% 10%;
+        }
+
+        th, td {
+            border: 1px solid black;
+            padding: 5px;
+            vertical-align: top;
+            text-align: left;
+        }
+
+    </style>
+</head>
+<body>
+<div><h1 style="text-align:center;">BOM Diff Summary</h1></div>
+<div class="table_summary2">
+    <div></div>
+    <div>
+        <table style="width: 100%">
+            <tr>
+                <th colspan="2"
+                    style="text-align: center; background-color: #d7ddde; border: 1px solid black;">
+                    Common Elements Summary
+                </th>
+            </tr>
+            {% for item in stats["common_summary"] %}
+                <tr>
+                    <td>{{ item[0] }}</td>
+                    <td style="text-align: right">{{ item[1] }}</td>
+
+                </tr>
+            {% endfor %}
+            <tr>
+                <td>Other matched:</td>
+                {% if misc_data_1 or misc_data_2 %}
+                    <td style="text-align: right">✖</td>
+                {% endif %}
+                {% if not (misc_data_1 or misc_data_2) %}
+                    <td style="text-align: right">✔</td>
+                {% endif %}
+            </tr>
+        </table>
+    </div>
+    <div></div>
+    <div>
+        <table style="width: 100%">
+            <tr>
+                <th colspan="3"
+                    style="text-align: center; background-color: #d7ddde; border: 1px solid black;">
+                    Unique Elements Breakdown
+                </th>
+            </tr>
+            <tr>
+                <td style="width: 20%"></td>
+                <th style="text-align: center; width: 40%">{{ bom_1 }}</th>
+                <th style="text-align: center; width: 40%">{{ bom_2 }}</th>
+            </tr>
+            {% for key, value in stats["breakdown"]|items %}
+                <tr>
+                    <td>{{ key }}</td>
+                    <td style="text-align: center; vertical-align: middle">{{ value[0] }}</td>
+                    <td style="text-align: center; vertical-align: middle">{{ value[1] }}</td>
+                </tr>
+            {% endfor %}
+        </table>
+    </div>
+    <div></div>
+</div>
+<br>
+<div class="table_summary">
+    <div></div>
+    <div>
+        <table style="width: 100%">
+            <tr>
+                <th colspan="3"
+                    style="text-align: center; background-color: #d7ddde; border: 1px solid black;">
+                    Element Diff
+                </th>
+            </tr>
+            {% if diff_status > 0 %}
+                <tr>
+                    <th style="width: 8%"></th>
+                    <th style="text-align: center; width: 46%">{{ bom_1 }}</th>
+                    <th style="text-align: center; width: 46%">{{ bom_2 }}</th>
+                </tr>
+            {% endif %}
+            {% if diff_status == 0 %}
+                <tr>
+                    <td colspan="3" style="text-align: center">No differences found.</td>
+                </tr>
+            {% endif %}
+            {% if diff_other_1 or diff_other_2 %}
+                <tr>
+                    <th>components<br><br>{{ diff_other_1 | length }}
+                        vs {{ diff_other_2 | length }}</th>
+                    <td><ul>{% for item in diff_other_1 %}
+                        <li>{{ item }}</li>
+                    {% endfor %}</ul></td>
+                    <td><ul>{% for item in diff_other_2 %}
+                        <li>{{ item }}</li>
+                    {% endfor %}</ul></td>
+                </tr>
+            {% endif %}
+            {% if diff_services_1 or diff_services_2 %}
+                <tr>
+                    <th>services<br><br>{{ diff_services_1 | length }}
+                        vs {{ diff_services_2 | length }}</th>
+                    <td>{% for item in diff_services_1 %}
+                        <details>
+                            <summary>{{ item['name'] }}</summary>
+                            <ul>
+                                {% for key, value in item|items %}
+                                    {% if value != "" %}
+                                        <li>{{ key }}: {{ value }}</li>
+                                    {% endif %}
+                                {% endfor %}
+                            </ul>
+                        </details>
+                    {% endfor %}</td>
+                    <td>{% for item in diff_services_2 %}
+                        <details>
+                            <summary>{{ item['name'] }}</summary>
+                            <ul>
+                                {% for key, value in item|items %}
+                                    {% if value != "" %}
+                                        <li>{{ key }}: {{ value }}</li>
+                                    {% endif %}
+                                {% endfor %}
+                            </ul>
+                        </details>
+                    {% endfor %}</td>
+                </tr>
+            {% endif %}
+            {% if diff_deps_1 or diff_deps_2 %}
+                <tr>
+                    <th>dependencies<br><br>{{ diff_deps_1 | length }}
+                        vs {{ diff_deps_2 | length }}</th>
+                    <td>{% for item in diff_deps_1 %}
+                        <details>
+                            <summary>{{ item['short_ref'] }}</summary>
+                            <ul>
+                                <li>ref: {{ item['ref'] }}</li>
+                            {% for key, value in item|items %}
+                                {% if key == "dependsOn" and value %}
+                                    <li>dependencies:
+                                        <ul>
+                                            {% for dep in item['dependsOn'] %}
+                                                <li>{{ dep }}</li>
+                                            {% endfor %}
+                                        </ul>
+                                    </li>
+                                {% endif %}
+                            {% endfor %}
+                            </ul>
+                        </details>
+                    {% endfor %}</td>
+                    <td>{% for item in diff_deps_2 %}
+                        <details>
+                            <summary>{{ item['short_ref'] }}</summary>
+                            <ul>
+                                <li>ref: {{ item['ref'] }}</li>
+                            {% for key, value in item|items %}
+                                {% if key == "dependsOn" and value %}
+                                    <li>dependencies:
+                                        <ul>
+                                            {% for dep in item['dependsOn'] %}
+                                                <li>{{ dep }}</li>
+                                            {% endfor %}
+                                        </ul>
+                                    </li>
+                                {% endif %}
+                            {% endfor %}
+                            </ul>
+                        </details>
+                    {% endfor %}</td>
+                </tr>
+            {% endif %}
+            {% if diff_vdrs_1 or diff_vdrs_2 %}
+                <tr>
+                    <th>vulnerabilities<br><br>{{ diff_vdrs_1 | length }}
+                        vs {{ diff_vdrs_2 | length }}</th>
+                    <td>{% for item in diff_vdrs_1 %}
+                        <details>
+                            <summary>{{ item['bom-ref'] }}</summary>
+                            <ul>
+                                {% for key, value in item|items %}
+                                    {% if value and key not in ["advisories","analysis","cwes","properties"] %}
+                                        {% if key == "source" %}
+                                            <li>
+                                                <details>
+                                                    <summary>{{ key }}:</summary>
+                                                    <ul>
+                                                        {% for skey, svalue in value|items %}
+                                                            <li>{{ skey }}: {{ svalue }}</li>
+                                                        {% endfor %}
+                                                    </ul>
+                                                </details>
+                                            </li>
+                                        {% endif %}
+                                        {% if key == "ratings" %}
+                                            <li>
+                                                <details>
+                                                    <summary>{{ key }}:</summary>
+                                                    <ul>
+                                                        {% for rating in value %}
+                                                            <li>
+                                                                <details>
+                                                                    <summary>{{ rating["vector"] }}:</summary>
+                                                                    <ul>
+                                                                        {% for rkey, rvalue in rating|items %}
+                                                                            <li>{{ rkey }}: {{ rvalue }}</li>
+                                                                        {% endfor %}
+                                                                    </ul>
+                                                                </details>
+                                                            </li>
+                                                        {% endfor %}
+                                                    </ul>
+                                                </details>
+                                            </li>
+                                        {% endif %}
+                                        {% if key == "references" %}
+                                            <li>
+                                                <details>
+                                                    <summary>{{ key }}:</summary>
+                                                    <ul>
+                                                        {% for ref in value %}
+                                                            <details>
+                                                                <summary>{{ ref['id'] }}:</summary>
+                                                                <ul>
+                                                                    <li>
+                                                                        name: {{ ref['source']['name'] }}</li>
+                                                                    <li>
+                                                                        url: {{ ref['source']['url'] }}</li>
+                                                                </ul>
+                                                            </details>
+                                                        {% endfor %}
+                                                    </ul>
+                                                </details>
+                                            </li>
+                                        {% endif %}
+                                        {% if key == "affects" %}
+                                            <li>
+                                                <details>
+                                                    <summary>{{ key }}:</summary>
+                                                    <ul>
+                                                        {% for affect in value %}
+                                                            {% for a, b in affect|items %}
+                                                                <li>{{ a }}: {{ b }}</li>
+                                                            {% endfor %}
+                                                        {% endfor %}
+                                                    </ul>
+                                                </details>
+                                            </li>
+                                        {% endif %}
+                                        {% if key == "detail" %}
+                                            <li>
+                                                <details>
+                                                    <summary>{{ key }}:</summary>
+                                                    <ul>
+                                                        <li>{{ value }}</li>
+                                                    </ul>
+                                                </details>
+                                            </li>
+                                        {% endif %}
+                                        {% if key not in ["source","ratings","references","affects","detail"] %}
+                                            <li>{{ key }}: {{ value }}</li>
+                                        {% endif %}
+                                    {% endif %}
+                                    {% if key in ["advisories","cwes","properties"] and value|length > 0 %}
+                                        <li>
+                                            <details>
+                                                <summary>{{ key }}:</summary>
+                                                <ul>
+                                                    {% for i in value %}
+                                                        <li>{{ i }}</li>
+                                                    {% endfor %}
+                                                </ul>
+                                            </details>
+                                        </li>
+                                    {% endif %}
+                                    {% if key == "analysis" and value|length > 0 %}
+                                        <li>
+                                            <details>
+                                                <summary>{{ key }}:</summary>
+                                                <ul>
+                                                    {% for a,b in value|items %}
+                                                        <li>{{ a }}: {{ b }}</li>
+                                                    {% endfor %}
+                                                </ul>
+                                            </details>
+                                        </li>
+                                    {% endif %}
+                                {% endfor %}
+                            </ul>
+                        </details>
+                    {% endfor %}</td>
+                    <td>{% for item in diff_vdrs_2 %}
+                        <details>
+                            <summary>{{ item['bom-ref'] }}</summary>
+                            <ul>
+                                {% for key, value in item|items %}
+                                    {% if value and key not in ["advisories","analysis","cwes","properties"] %}
+                                        {% if key == "source" %}
+                                            <li>
+                                                <details>
+                                                    <summary>{{ key }}:</summary>
+                                                    <ul>
+                                                        {% for skey, svalue in value|items %}
+                                                            <li>{{ skey }}: {{ svalue }}</li>
+                                                        {% endfor %}
+                                                    </ul>
+                                                </details>
+                                            </li>
+                                        {% endif %}
+                                        {% if key == "ratings" %}
+                                            <li>
+                                                <details>
+                                                    <summary>{{ key }}:</summary>
+                                                    <ul>
+                                                        {% for rating in value %}
+                                                            <li>
+                                                                <details>
+                                                                    <summary>{{ rating["vector"] }}:</summary>
+                                                                    <ul>
+                                                                        {% for rkey, rvalue in rating|items %}
+                                                                            <li>{{ rkey }}: {{ rvalue }}</li>
+                                                                        {% endfor %}
+                                                                    </ul>
+                                                                </details>
+                                                            </li>
+                                                        {% endfor %}
+                                                    </ul>
+                                                </details>
+                                            </li>
+                                        {% endif %}
+                                        {% if key == "references" %}
+                                            <li>
+                                                <details>
+                                                    <summary>{{ key }}:</summary>
+                                                    <ul>
+                                                        {% for ref in value %}
+                                                            <details>
+                                                                <summary>{{ ref['id'] }}:</summary>
+                                                                <ul>
+                                                                    <li>
+                                                                        name: {{ ref['source']['name'] }}</li>
+                                                                    <li>
+                                                                        url: {{ ref['source']['url'] }}</li>
+                                                                </ul>
+                                                            </details>
+                                                        {% endfor %}
+                                                    </ul>
+                                                </details>
+                                            </li>
+                                        {% endif %}
+                                        {% if key == "affects" %}
+                                            <li>
+                                                <details>
+                                                    <summary>{{ key }}:</summary>
+                                                    <ul>
+                                                        {% for affect in value %}
+                                                            {% for a, b in affect|items %}
+                                                                <li>{{ a }}: {{ b }}</li>
+                                                            {% endfor %}
+                                                        {% endfor %}
+                                                    </ul>
+                                                </details>
+                                            </li>
+                                        {% endif %}
+                                        {% if key == "detail" %}
+                                            <li>
+                                                <details>
+                                                    <summary>{{ key }}:</summary>
+                                                    <ul>
+                                                        <li>{{ value }}</li>
+                                                    </ul>
+                                                </details>
+                                            </li>
+                                        {% endif %}
+                                        {% if key not in ["source","ratings","references","affects","detail"] %}
+                                            <li>{{ key }}: {{ value }}</li>
+                                        {% endif %}
+                                    {% endif %}
+                                    {% if key in ["advisories","cwes","properties"] and value|length > 0 %}
+                                        <li>
+                                            <details>
+                                                <summary>{{ key }}:</summary>
+                                                <ul>
+                                                    {% for i in value %}
+                                                        <li>{{ i }}</li>
+                                                    {% endfor %}
+                                                </ul>
+                                            </details>
+                                        </li>
+                                    {% endif %}
+                                    {% if key == "analysis" and value|length > 0 %}
+                                        <li>
+                                            <details>
+                                                <summary>{{ key }}:</summary>
+                                                <ul>
+                                                    {% for a,b in value|items %}
+                                                        <li>{{ a }}: {{ b }}</li>
+                                                    {% endfor %}
+                                                </ul>
+                                            </details>
+                                        </li>
+                                    {% endif %}
+                                {% endfor %}
+                            </ul>
+                        </details>
+                    {% endfor %}</td>
+                </tr>
+            {% endif %}
+            {% if misc_data_1 or misc_data_2 %}
+                <tr>
+                    <th>other</th>
+                    {% if misc_data_1 %}
+                        <td>{{ misc_data_1 }}</td>
+                    {% endif %}
+                    {% if not misc_data_1 %}
+                        <td></td>
+                    {% endif %}
+                    {% if misc_data_2 %}
+                        <td>{{ misc_data_2 }}</td>
+                    {% endif %}
+                    {% if not misc_data_2 %}
+                        <td></td>
+                    {% endif %}
+                </tr>
+            {% endif %}
+        </table>
+    </div>
+    <div></div>
+</div>
+<br>
+<div class="table_summary">
+    <div></div>
+    <div>
+        <table style="width: 100%">
+            <tr>
+                <th colspan="2"
+                    style="text-align: center; background-color: #d7ddde; border: 1px solid black;">
+                    Common
+                    Elements
+                </th>
+            </tr>
+            {% if not (common_other or common_services or common_deps or common_vdrs or common_misc_data) %}
+                <tr>
+                    <td colspan="2" style="text-align: center">No commonalities.</td>
+                </tr>
+            {% endif %}
+            {% if common_other %}
+                <tr>
+                    <th>components<br><br>{{ common_other | length }}</th>
+                    <td style="width: 41%"><ul>{% for item in common_other %}
+                        <li>{{ item }}</li>
+                    {% endfor %}</ul></td>
+                </tr>
+            {% endif %}
+            {% if common_services %}
+                <tr>
+                    <th style="width: 8%">services<br><br>{{ common_services | length }}</th>
+                    <td style="width: 41%">{% for item in common_services %}
+                        <details>
+                            <summary>{{ item['name'] }}</summary>
+                            <ul>
+                                {% for key, value in item|items %}
+                                    {% if value != "" %}
+                                        <li>{{ key }}: {{ value }}</li>
+                                    {% endif %}
+                                {% endfor %}
+                            </ul>
+                        </details>
+                    {% endfor %}</td>
+                </tr>
+            {% endif %}
+            {% if common_deps %}
+                <tr>
+                    <th style="width: 8%">dependencies<br><br>{{ common_deps | length }}</th>
+                    <td style="width: 41%">{% for item in common_deps %}
+                        <details>
+                            <summary>{{ item['short_ref'] }}</summary>
+                            <ul>
+                                <li>ref: {{ item['ref'] }}</li>
+                            {% for key, value in item|items %}
+                                {% if key == "dependsOn" and value %}
+                                    <li>dependencies:
+                                        <ul>
+                                            {% for dep in item['dependsOn'] %}
+                                                <li>{{ dep }}</li>
+                                            {% endfor %}
+                                        </ul>
+                                    </li>
+                                {% endif %}
+                            {% endfor %}
+                            </ul>
+                        </details>
+                    {% endfor %}</td>
+                </tr>
+            {% endif %}
+            {% if common_vdrs %}
+                <tr>
+                    <th style="width: 8%">vulnerabilities<br><br>{{ common_vdrs | length }}</th>
+                    <td style="width: 41%">{% for item in common_vdrs %}
+                        <details>
+                            <summary>{{ item['bom-ref'] }}</summary>
+                            <ul>
+                                {% for key, value in item|items %}
+                                    {% if value and key not in ["advisories","analysis","cwes","properties"] %}
+                                        {% if key == "source" %}
+                                            <li>
+                                                <details>
+                                                    <summary>{{ key }}:</summary>
+                                                    <ul>
+                                                        {% for skey, svalue in value|items %}
+                                                            <li>{{ skey }}: {{ svalue }}</li>
+                                                        {% endfor %}
+                                                    </ul>
+                                                </details>
+                                            </li>
+                                        {% endif %}
+                                        {% if key == "ratings" %}
+                                            <li>
+                                                <details>
+                                                    <summary>{{ key }}:</summary>
+                                                    <ul>
+                                                        {% for rating in value %}
+                                                            <li>
+                                                                <details>
+                                                                    <summary>{{ rating["vector"] }}:</summary>
+                                                                    <ul>
+                                                                        {% for rkey, rvalue in rating|items %}
+                                                                            <li>{{ rkey }}: {{ rvalue }}</li>
+                                                                        {% endfor %}
+                                                                    </ul>
+                                                                </details>
+                                                            </li>
+                                                        {% endfor %}
+                                                    </ul>
+                                                </details>
+                                            </li>
+                                        {% endif %}
+                                        {% if key == "references" %}
+                                            <li>
+                                                <details>
+                                                    <summary>{{ key }}:</summary>
+                                                    <ul>
+                                                        {% for ref in value %}
+                                                            <details>
+                                                                <summary>{{ ref['id'] }}:</summary>
+                                                                <ul>
+                                                                    <li>
+                                                                        name: {{ ref['source']['name'] }}</li>
+                                                                    <li>
+                                                                        url: {{ ref['source']['url'] }}</li>
+                                                                </ul>
+                                                            </details>
+                                                        {% endfor %}
+                                                    </ul>
+                                                </details>
+                                            </li>
+                                        {% endif %}
+                                        {% if key == "affects" %}
+                                            <li>
+                                                <details>
+                                                    <summary>{{ key }}:</summary>
+                                                    <ul>
+                                                        {% for affect in value %}
+                                                            {% for a, b in affect|items %}
+                                                                <li>{{ a }}: {{ b }}</li>
+                                                            {% endfor %}
+                                                        {% endfor %}
+                                                    </ul>
+                                                </details>
+                                            </li>
+                                        {% endif %}
+                                        {% if key == "detail" %}
+                                            <li>
+                                                <details>
+                                                    <summary>{{ key }}:</summary>
+                                                    <ul>
+                                                        <li>{{ value }}</li>
+                                                    </ul>
+                                                </details>
+                                            </li>
+                                        {% endif %}
+                                        {% if key not in ["source","ratings","references","affects","detail"] %}
+                                            <li>{{ key }}: {{ value }}</li>
+                                        {% endif %}
+                                    {% endif %}
+                                    {% if key in ["advisories","cwes","properties"] and value|length > 0 %}
+                                        <li>
+                                            <details>
+                                                <summary>{{ key }}:</summary>
+                                                <ul>
+                                                    {% for i in value %}
+                                                        <li>{{ i }}</li>
+                                                    {% endfor %}
+                                                </ul>
+                                            </details>
+                                        </li>
+                                    {% endif %}
+                                    {% if key == "analysis" and value|length > 0 %}
+                                        <li>
+                                            <details>
+                                                <summary>{{ key }}:</summary>
+                                                <ul>
+                                                    {% for a,b in value|items %}
+                                                        <li>{{ a }}: {{ b }}</li>
+                                                    {% endfor %}
+                                                </ul>
+                                            </details>
+                                        </li>
+                                    {% endif %}
+                                {% endfor %}
+                            </ul>
+                        </details>
+                    {% endfor %}</td>
+                </tr>
+            {% endif %}
+            {% if common_misc_data %}
+                <tr>
+                    <th style="width: 8%">other</th>
+                    <td style="width: 41%">{{ common_misc_data }}</td>
+                </tr>
+            {% endif %}
+        </table>
+    </div>
+    <div></div>
+</div>
+<br>
+</body>
+</html>

--- a/custom_json_diff/lib/custom_diff.py
+++ b/custom_json_diff/lib/custom_diff.py
@@ -118,7 +118,7 @@ def generate_bom_diff(bom: BomDicts, commons: BomDicts, common_refs: Dict) -> Di
 
 
 def get_unique_components(bom: BomDicts, common_refs: Dict):
-    components = {"applications": [], "frameworks": [], "libraries": [], "other_components": []}
+    components: Dict[str, List] = {"applications": [], "frameworks": [], "libraries": [], "other_components": []}
     if bom.options.bom_profile:
         for i in bom.components:
             match bom.options.bom_profile:

--- a/custom_json_diff/lib/custom_diff.py
+++ b/custom_json_diff/lib/custom_diff.py
@@ -108,26 +108,43 @@ def generate_counts(data: Dict) -> Dict:
 
 
 def generate_bom_diff(bom: BomDicts, commons: BomDicts, common_refs: Dict) -> Dict:
-    diff_summary = {
-        "components": {"applications": [], "frameworks": [], "libraries": [],
-                                   "other_components": []},
+    return {
+        "components": get_unique_components(bom, common_refs),
         "dependencies": [i.to_dict() for i in bom.dependencies if i.ref not in common_refs["dependencies"]],
         "services": [i.to_dict() for i in bom.services if i.search_key not in common_refs["services"]],
-        "vulnerabilities": [i.to_dict() for i in bom.vdrs if i.bom_ref not in common_refs["vdrs"]]
+        "vulnerabilities": [i.to_dict() for i in bom.vdrs if i.bom_ref not in common_refs["vdrs"]],
+        "misc_data": (bom.misc_data - commons.misc_data).to_dict()
     }
-    for i in bom.components:
-        if i.bom_ref not in common_refs["components"]:
-            match i.component_type:
-                case "application":
-                    diff_summary["components"]["applications"].append(i.to_dict())  #type: ignore
-                case "framework":
-                    diff_summary["components"]["frameworks"].append(i.to_dict())  #type: ignore
-                case "library":
-                    diff_summary["components"]["libraries"].append(i.to_dict())  #type: ignore
+
+
+def get_unique_components(bom: BomDicts, common_refs: Dict):
+    components = {"applications": [], "frameworks": [], "libraries": [], "other_components": []}
+    if bom.options.bom_profile:
+        for i in bom.components:
+            match bom.options.bom_profile:
+                case "nv":
+                    key = f"{i.name}@{i.version}"
+                case "gn":
+                    key = f"{i.group}/{i.name}"
                 case _:
-                    diff_summary["components"]["other_components"].append(i.to_dict())  #type: ignore
-    diff_summary["misc_data"] = (bom.misc_data - commons.misc_data).to_dict()
-    return diff_summary
+                    key = f"{i.group}/{i.name}@{i.version}"
+            if key not in common_refs["components"]:
+                components["other_components"].append(i.to_dict())
+        return components
+    for i in bom.components:
+        key = i.bom_ref if "components.[].bom_ref" not in bom.options.exclude else f"{i.group}/{i.name}@{i.version}"
+        if key in common_refs["components"]:
+            continue
+        match i.component_type:
+            case "application":
+                components["applications"].append(i.to_dict())  # type: ignore
+            case "framework":
+                components["frameworks"].append(i.to_dict())  # type: ignore
+            case "library":
+                components["libraries"].append(i.to_dict())  # type: ignore
+            case _:
+                components["other_components"].append(i.to_dict())  # type: ignore
+    return components
 
 
 def generate_csaf_diff(csaf: CsafDicts, commons: CsafDicts, common_refs: Dict[str, Set]) -> Dict:

--- a/custom_json_diff/lib/custom_diff_classes.py
+++ b/custom_json_diff/lib/custom_diff_classes.py
@@ -391,18 +391,18 @@ class BomDicts(OptionedClass):
         _, _, _, _, self._vdrs = import_bom_dict(self.options, {}, vulnerabilities=value)
 
     def intersection(self, other, title: str = "") -> "BomDicts":
-        components = []
-        dependencies = []
-        services = []
-        vulnerabilities = []
+        components = Array([])
+        dependencies = Array([])
+        services = Array([])
+        vulnerabilities = Array([])
         if self.components and other.components:
-            components = [i for i in self.components if i in other.components]
+            components = Array([i for i in self.components if i in other.components])
         if self.services and other.services:
-            services = [i for i in self.services if i in other.services]
+            services = Array([i for i in self.services if i in other.services])
         if self.dependencies and other.dependencies:
-            dependencies = [i for i in self.dependencies if i in other.dependencies]
+            dependencies = Array([i for i in self.dependencies if i in other.dependencies])
         if self.vdrs and other.vdrs:
-            vulnerabilities = [i for i in self.vdrs if i in other.vdrs]
+            vulnerabilities = Array([i for i in self.vdrs if i in other.vdrs])
         other_data = self.misc_data.intersection(other.misc_data)
         options = deepcopy(self.options)
         return BomDicts(
@@ -436,12 +436,21 @@ class BomDicts(OptionedClass):
                 "vulnerabilities": len(self.vdrs)}
 
     def get_refs(self) -> Dict:
-        return {
-            "components": {i.bom_ref for i in self.components},
-            "dependencies": {i.ref for i in self.dependencies},
-            "services": {i.search_key for i in self.services},
-            "vdrs": {i.bom_ref for i in self.vdrs}
-        }
+        refs = {
+                "dependencies": {i.ref for i in self.dependencies},
+                "services": {i.search_key for i in self.services},
+                "vdrs": {i.bom_ref for i in self.vdrs}
+            }
+        match self.options.bom_profile:
+            case "gnv":
+                refs |= {"components": {f"{i.group}/{i.name}@{i.version}" for i in self.components}}
+            case "gn":
+                refs |= {"components": {f"{i.group}/{i.name}" for i in self.components}}
+            case "nv":
+                refs |= {"components": {f"{i.name}@{i.version}" for i in self.components}}
+            case _:
+                refs |= {"components": {i.bom_ref for i in self.components}}
+        return refs
 
     def to_dict(self) -> Dict:
         return {

--- a/custom_json_diff/lib/custom_diff_classes.py
+++ b/custom_json_diff/lib/custom_diff_classes.py
@@ -1040,7 +1040,7 @@ def import_bom_dict(
         if not value:
             elements[i] = []
     components, services, dependencies, vulnerabilities = elements
-    return other_data, Array(components), Array(services), Array(dependencies), Array(vulnerabilities)  # type: ignore
+    return other_data, Array(dedupe_components(components)), Array(services), Array(dependencies), Array(vulnerabilities)  # type: ignore
 
 
 def import_csaf(options: "Options", original_data: Dict | None = None, document: FlatDicts | None = None,
@@ -1101,3 +1101,11 @@ def parse_bom_dict(original_data: Dict, options: Options) -> Tuple[FlatDicts, Li
         if key not in {"components", "dependencies", "services", "vulnerabilities"}:
             other_data |= {key: value}
     return FlatDicts(other_data), components, services, dependencies, vulnerabilities
+
+
+def dedupe_components(components: List) -> List:
+    deduped = []
+    for component in components:
+        if component not in deduped:
+            deduped.append(component)
+    return deduped

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "custom-json-diff"
-version = "2.1.3"
+version = "2.1.4"
 description = "CycloneDx BOM and Oasis CSAF diffing and comparison tool."
 authors = [
   { name = "Caroline Russell", email = "caroline@appthreat.dev" },


### PR DESCRIPTION
Fixes various bugs in --bom-profile, namely that the argument was not set in cli.py and reliance on bom-ref to identify unique and common components. Also offers a simpler HTML report. Please note the component list is now being deduped as limiting to 2-3 fields for comparison results in multiple components which are indistinguishable from each other - e.g. when multiple versions of the same component are present in the bom but we are excluding the version from comparison.